### PR TITLE
Add project settings for width, height and fps

### DIFF
--- a/libs/mva_gui/src/items/abstractitem.cpp
+++ b/libs/mva_gui/src/items/abstractitem.cpp
@@ -19,7 +19,7 @@ void AbstractItem::setName(const QString& name)
         return;
     }
     m_name = name;
-    nameChanged(m_name);
+    emit nameChanged(m_name);
 }
 
 QColor AbstractItem::color() const
@@ -33,7 +33,7 @@ void AbstractItem::setColor(const QColor& color)
         return;
     }
     m_color = color;
-    colorChanged(m_color);
+    emit colorChanged(m_color);
 }
 
 QJsonObject AbstractItem::toJson() const

--- a/libs/mva_workflow/include/workflow/itemhandler.h
+++ b/libs/mva_workflow/include/workflow/itemhandler.h
@@ -7,14 +7,12 @@
 
 #include "abstractitem.h"
 
-class PropertyModel : public QStandardItemModel
-{
+class PropertyModel : public QStandardItemModel {
 public:
-    Qt::ItemFlags flags(const QModelIndex &index) const;
+    Qt::ItemFlags flags(const QModelIndex& index) const;
 };
 
-class ItemHandler : public QObject
-{
+class ItemHandler : public QObject {
     Q_OBJECT
 public:
     enum ItemRoles { QUICKITEM = Qt::UserRole + 1 };
@@ -22,22 +20,28 @@ public:
     explicit ItemHandler(QObject* parent = nullptr);
 
     qsizetype numItems() const { return m_itemmodel.rowCount(); }
-    QStandardItemModel *model() { return &m_itemmodel; }
-    QStandardItemModel *propertyModel() { return &m_propertymodel; }
+    QStandardItemModel* model() { return &m_itemmodel; }
+    QStandardItemModel* propertyModel() { return &m_propertymodel; }
     QList<QQuickItem*> items();
 
 public slots:
     void clear();
 
-    void addItem(QQuickItem *const quick_item);
-    void removeItem(QQuickItem *const quick_item);
+    void addItem(QQuickItem* const quick_item);
+    void removeItem(QQuickItem* const quick_item);
 
     void setCurrentRow(const int row);
 
+    void recalcItemsX(const qreal ratio);
+    void recalcItemsY(const qreal ratio);
+
+    void recalcItemsWidth(const qreal ratio);
+    void recalcItemsHeight(const qreal ratio);
+
 private slots:
-    void propertyDataChanged(const QModelIndex &topLeft,
-                             const QModelIndex &bottomRight,
-                             const QList<int> &roles = QList<int>());
+    void propertyDataChanged(const QModelIndex& topLeft,
+        const QModelIndex& bottomRight,
+        const QList<int>& roles = QList<int>());
 
 private:
     struct ItemExtract {
@@ -59,7 +63,7 @@ private:
 
 class ItemModelItem : public QStandardItem {
 public:
-    explicit ItemModelItem(const QString &text);
+    explicit ItemModelItem(const QString& text);
 
     ~ItemModelItem();
 };

--- a/libs/mva_workflow/include/workflow/renderer.h
+++ b/libs/mva_workflow/include/workflow/renderer.h
@@ -10,7 +10,16 @@
 class Renderer : public QObject {
     Q_OBJECT
 public:
+    struct ProjectSettings {
+        qint32 width = 1024;
+        qint32 height = 768;
+        qint32 fps = 24;
+    };
+
     explicit Renderer(QObject* parent = nullptr);
+
+    ProjectSettings projectSettings() const;
+    void setProjectSettings(const ProjectSettings& new_project_settings);
 
 public slots:
     void render(const QList<AbstractItem*>& item_list);
@@ -23,7 +32,8 @@ private slots:
     void renderingProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
 
 private:
-    QProcess renderProcess;
+    QProcess m_render_process;
+    ProjectSettings m_project_settings;
 };
 
 #endif // RENDERER_H

--- a/libs/mva_workflow/src/itemhandler.cpp
+++ b/libs/mva_workflow/src/itemhandler.cpp
@@ -147,6 +147,42 @@ void ItemHandler::setCurrentRow(const int row)
     // TODO: sort elements?
 }
 
+void ItemHandler::recalcItemsX(const qreal ratio)
+{
+    const auto itemList = items();
+
+    for (auto &item : itemList) {
+        item->setX(qRound(item->x() * ratio));
+    }
+}
+
+void ItemHandler::recalcItemsY(const qreal ratio)
+{
+    const auto itemList = items();
+
+    for (auto &item : itemList) {
+        item->setY(qRound(item->y() * ratio));
+    }
+}
+
+void ItemHandler::recalcItemsWidth(const qreal ratio)
+{
+    const auto itemList = items();
+
+    for (auto &item : itemList) {
+        item->setWidth(qRound(item->width() * ratio));
+    }
+}
+
+void ItemHandler::recalcItemsHeight(const qreal ratio)
+{
+    const auto itemList = items();
+
+    for (auto &item : itemList) {
+        item->setHeight(qRound(item->height() * ratio));
+    }
+}
+
 // TODO: Refactor this
 // TODO: Create custom ItemModels and items which contain pointers to the data, s.t. this will be done automatically
 void ItemHandler::propertyDataChanged(const QModelIndex& topLeft,

--- a/libs/mva_workflow/tests/tst_itemhandler.cpp
+++ b/libs/mva_workflow/tests/tst_itemhandler.cpp
@@ -5,8 +5,7 @@
 
 #include "itemhandler.h"
 
-class TestItemHandler : public QObject
-{
+class TestItemHandler : public QObject {
     Q_OBJECT
 private slots:
 
@@ -21,6 +20,12 @@ private slots:
 
     void changeItemProperty();
 
+    void recalcItemsPosX();
+    void recalcItemsPosY();
+
+    void recalcItemsWidth();
+    void recalcItemsHeight();
+
     void getItems();
 
     void removeItem();
@@ -33,16 +38,16 @@ private:
     QQmlEngine m_engine;
     QQmlComponent m_circle_component
         = QQmlComponent(&m_engine,
-                        QUrl(QStringLiteral("qrc:/qt/qml/cwa/mva/gui/qml/items/MVACircle.qml")));
+            QUrl(QStringLiteral("qrc:/qt/qml/cwa/mva/gui/qml/items/MVACircle.qml")));
     QQmlComponent m_rect_component
         = QQmlComponent(&m_engine,
-                        QUrl(QStringLiteral("qrc:/qt/qml/cwa/mva/gui/qml/items/MVARectangle.qml")));
+            QUrl(QStringLiteral("qrc:/qt/qml/cwa/mva/gui/qml/items/MVARectangle.qml")));
 };
 
 void TestItemHandler::addItem()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    auto rect = dynamic_cast<QQuickItem *>(m_rect_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
 
     ItemHandler itemhandler;
     QCOMPARE(itemhandler.numItems(), 0);
@@ -56,7 +61,7 @@ void TestItemHandler::addItem()
 
 void TestItemHandler::addItemDuplicate()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
 
     ItemHandler itemhandler;
 
@@ -68,8 +73,8 @@ void TestItemHandler::addItemDuplicate()
 
 void TestItemHandler::addItemWithSameName()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    auto circle_1 = dynamic_cast<QQuickItem *>(m_circle_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto circle_1 = dynamic_cast<QQuickItem*>(m_circle_component.create());
 
     ItemHandler itemhandler;
 
@@ -88,9 +93,9 @@ void TestItemHandler::addItemWithSameName()
 
 void TestItemHandler::addItemWithSameName2()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    auto circle_1 = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    auto circle_2 = dynamic_cast<QQuickItem *>(m_circle_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto circle_1 = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto circle_2 = dynamic_cast<QQuickItem*>(m_circle_component.create());
 
     ItemHandler itemhandler;
 
@@ -123,16 +128,16 @@ void TestItemHandler::addIncompatibleItem()
 
 void TestItemHandler::checkItemData()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    auto rect = dynamic_cast<QQuickItem *>(m_rect_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
 
     const int circleHeight = 123;
     const int rectHeight = 123;
     circle->setHeight(circleHeight);
     rect->setHeight(rectHeight);
 
-    const auto circle_item = qvariant_cast<AbstractItem *>(circle->property("item"));
-    const auto rect_item = qvariant_cast<AbstractItem *>(rect->property("item"));
+    const auto circle_item = qvariant_cast<AbstractItem*>(circle->property("item"));
+    const auto rect_item = qvariant_cast<AbstractItem*>(rect->property("item"));
 
     ItemHandler itemhandler;
     itemhandler.addItem(circle);
@@ -145,23 +150,23 @@ void TestItemHandler::checkItemData()
     const auto rect_item_2 = model->item(1, 1);
 
     QCOMPARE(circle_item_1->data(Qt::DisplayRole), circle_item->name());
-    QCOMPARE(circle_item_1->data(ItemHandler::ItemRoles::QUICKITEM).value<QQuickItem *>(), circle);
-    QCOMPARE(circle_item_1->data(ItemHandler::ItemRoles::QUICKITEM).value<QQuickItem *>()->height(),
-             circleHeight);
+    QCOMPARE(circle_item_1->data(ItemHandler::ItemRoles::QUICKITEM).value<QQuickItem*>(), circle);
+    QCOMPARE(circle_item_1->data(ItemHandler::ItemRoles::QUICKITEM).value<QQuickItem*>()->height(),
+        circleHeight);
     QCOMPARE(circle_item_2->data(Qt::DisplayRole), "CircleItem");
     QCOMPARE(rect_item_1->data(Qt::DisplayRole), rect_item->name());
-    QCOMPARE(rect_item_1->data(ItemHandler::ItemRoles::QUICKITEM).value<QQuickItem *>(), rect);
-    QCOMPARE(rect_item_1->data(ItemHandler::ItemRoles::QUICKITEM).value<QQuickItem *>()->height(),
-             rectHeight);
+    QCOMPARE(rect_item_1->data(ItemHandler::ItemRoles::QUICKITEM).value<QQuickItem*>(), rect);
+    QCOMPARE(rect_item_1->data(ItemHandler::ItemRoles::QUICKITEM).value<QQuickItem*>()->height(),
+        rectHeight);
     QCOMPARE(rect_item_2->data(Qt::DisplayRole), "RectangleItem");
 }
 
 void TestItemHandler::checkItemProperties()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    auto rect = dynamic_cast<QQuickItem *>(m_rect_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
 
-    const auto circle_item = qvariant_cast<AbstractItem *>(circle->property("item"));
+    const auto circle_item = qvariant_cast<AbstractItem*>(circle->property("item"));
 
     ItemHandler itemhandler;
     itemhandler.addItem(circle);
@@ -181,8 +186,8 @@ void TestItemHandler::checkItemProperties()
 
 void TestItemHandler::changeItemProperty()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    const auto circle_item = qvariant_cast<AbstractItem *>(circle->property("item"));
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    const auto circle_item = qvariant_cast<AbstractItem*>(circle->property("item"));
 
     ItemHandler itemhandler;
     itemhandler.addItem(circle);
@@ -201,10 +206,122 @@ void TestItemHandler::changeItemProperty()
     QCOMPARE(item_model_circle->data(Qt::DisplayRole).toString(), new_name);
 }
 
+void TestItemHandler::recalcItemsPosX()
+{
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
+
+    const qreal circle_x_old = 200;
+    const qreal circle_y_old = 100;
+    const qreal rect_x_old = 154;
+    const qreal rect_y_old = 432;
+
+    circle->setX(circle_x_old);
+    circle->setY(circle_y_old);
+    rect->setX(rect_x_old);
+    rect->setY(rect_y_old);
+
+    ItemHandler itemhandler;
+    itemhandler.addItem(circle);
+    itemhandler.addItem(rect);
+
+    const qreal ratio = 0.65;
+    itemhandler.recalcItemsX(ratio);
+
+    QCOMPARE(circle->x(), qRound(circle_x_old * ratio));
+    QCOMPARE(circle->y(), circle_y_old);
+    QCOMPARE(rect->x(), qRound(rect_x_old * ratio));
+    QCOMPARE(rect->y(), rect_y_old);
+}
+
+void TestItemHandler::recalcItemsPosY()
+{
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
+
+    const qreal circle_x_old = 200;
+    const qreal circle_y_old = 100;
+    const qreal rect_x_old = 154;
+    const qreal rect_y_old = 432;
+
+    circle->setX(circle_x_old);
+    circle->setY(circle_y_old);
+    rect->setX(rect_x_old);
+    rect->setY(rect_y_old);
+
+    ItemHandler itemhandler;
+    itemhandler.addItem(circle);
+    itemhandler.addItem(rect);
+
+    const qreal ratio = 1.4;
+    itemhandler.recalcItemsY(ratio);
+
+    QCOMPARE(circle->x(), circle_x_old);
+    QCOMPARE(circle->y(), qRound(circle_y_old * ratio));
+    QCOMPARE(rect->x(), rect_x_old);
+    QCOMPARE(rect->y(), qRound(rect_y_old * ratio));
+}
+
+void TestItemHandler::recalcItemsWidth()
+{
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
+
+    const qreal circle_width_old = 200;
+    const qreal circle_height_old = 130;
+    const qreal rect_width_old = 154;
+    const qreal rect_height_old = 432;
+
+    circle->setWidth(circle_width_old);
+    circle->setHeight(circle_height_old);
+    rect->setWidth(rect_width_old);
+    rect->setHeight(rect_height_old);
+
+    ItemHandler itemhandler;
+    itemhandler.addItem(circle);
+    itemhandler.addItem(rect);
+
+    const qreal ratio = 1.2;
+    itemhandler.recalcItemsWidth(ratio);
+
+    QCOMPARE(circle->width(), qRound(circle_width_old * ratio));
+    QCOMPARE(circle->height(), circle_height_old);
+    QCOMPARE(rect->width(), qRound(rect_width_old * ratio));
+    QCOMPARE(rect->height(), rect_height_old);
+}
+
+void TestItemHandler::recalcItemsHeight()
+{
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
+
+    const qreal circle_width_old = 200;
+    const qreal circle_height_old = 130;
+    const qreal rect_width_old = 154;
+    const qreal rect_height_old = 432;
+
+    circle->setWidth(circle_width_old);
+    circle->setHeight(circle_height_old);
+    rect->setWidth(rect_width_old);
+    rect->setHeight(rect_height_old);
+
+    ItemHandler itemhandler;
+    itemhandler.addItem(circle);
+    itemhandler.addItem(rect);
+
+    const qreal ratio = 0.4;
+    itemhandler.recalcItemsHeight(ratio);
+
+    QCOMPARE(circle->height(), qRound(circle_height_old * ratio));
+    QCOMPARE(circle->width(), circle_width_old);
+    QCOMPARE(rect->height(), qRound(rect_height_old * ratio));
+    QCOMPARE(rect->width(), rect_width_old);
+}
+
 void TestItemHandler::getItems()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    auto rect = dynamic_cast<QQuickItem *>(m_rect_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
 
     ItemHandler itemhandler;
     itemhandler.addItem(circle);
@@ -218,7 +335,7 @@ void TestItemHandler::getItems()
 
 void TestItemHandler::removeItem()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
 
     ItemHandler itemhandler;
 
@@ -230,8 +347,8 @@ void TestItemHandler::removeItem()
 
 void TestItemHandler::removeMultipleItems()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    auto rect = dynamic_cast<QQuickItem *>(m_rect_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
 
     ItemHandler itemhandler;
 
@@ -247,8 +364,8 @@ void TestItemHandler::removeMultipleItems()
 
 void TestItemHandler::removeNonExistingItem()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    auto rect = dynamic_cast<QQuickItem *>(m_rect_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
 
     ItemHandler itemhandler;
 
@@ -260,8 +377,8 @@ void TestItemHandler::removeNonExistingItem()
 
 void TestItemHandler::clearHandler()
 {
-    auto circle = dynamic_cast<QQuickItem *>(m_circle_component.create());
-    auto rect = dynamic_cast<QQuickItem *>(m_rect_component.create());
+    auto circle = dynamic_cast<QQuickItem*>(m_circle_component.create());
+    auto rect = dynamic_cast<QQuickItem*>(m_rect_component.create());
 
     ItemHandler itemhandler;
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -7,17 +7,21 @@
 #include "abstractitem.h"
 #include "logging.h"
 
-MainWindowHandler::MainWindowHandler(QQmlApplicationEngine* const engine)
-    : m_qml_engine(engine)
+MainWindowHandler::MainWindowHandler()
 {
-    m_qml_engine->rootContext()->setContextProperty(QStringLiteral("main_window"), this);
-    m_qml_engine->rootContext()->setContextProperty(QStringLiteral("item_model"),
-        m_itemhandler.model());
-    m_qml_engine->rootContext()->setContextProperty(QStringLiteral("property_model"),
-        m_itemhandler.propertyModel());
-
     m_savefile_handler.setSaveDir(
         QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+}
+
+void MainWindowHandler::initEngine(QQmlApplicationEngine *const engine)
+{
+    m_qml_engine = engine;
+
+    m_qml_engine->rootContext()->setContextProperty(QStringLiteral("main_window"), this);
+    m_qml_engine->rootContext()->setContextProperty(QStringLiteral("item_model"),
+                                                    m_itemhandler.model());
+    m_qml_engine->rootContext()->setContextProperty(QStringLiteral("property_model"),
+                                                    m_itemhandler.propertyModel());
 }
 
 void MainWindowHandler::init()
@@ -30,7 +34,7 @@ void MainWindowHandler::init()
         return;
     }
 
-    m_qml_creation_area = rootObjects.first()->findChild<QObject*>("creationArea");
+    m_qml_creation_area = rootObjects.first()->findChild<QObject *>("creationArea");
 
     if (!m_qml_creation_area) {
         qCCritical(mainwindow_handler) << "Can't find creation area for videos. Init aborted.";
@@ -38,33 +42,33 @@ void MainWindowHandler::init()
     }
 
     // clang-format off
-    QObject::connect(m_qml_creation_area,
-                     SIGNAL(itemAdded(QQuickItem*)),
-                     this,
-                     SLOT(addItem(QQuickItem*)));
+            QObject::connect(m_qml_creation_area,
+                             SIGNAL(itemAdded(QQuickItem*)),
+                             this,
+                             SLOT(addItem(QQuickItem*)));
     // clang-format on
 }
 
 void MainWindowHandler::render()
 {
-    QList<AbstractItem*> abstractitem_list;
+    QList<AbstractItem *> abstractitem_list;
 
     const auto item_list = m_itemhandler.items();
-    for (const auto& item : item_list) {
-        abstractitem_list.push_back(qvariant_cast<AbstractItem*>(item->property("item")));
+    for (const auto &item : item_list) {
+        abstractitem_list.push_back(qvariant_cast<AbstractItem *>(item->property("item")));
     }
     m_renderer.render(abstractitem_list);
 }
 
-void MainWindowHandler::save(const QVariant& file)
+void MainWindowHandler::save(const QVariant &file)
 {
     QJsonObject save_json;
     int count = 0;
     QString element_prefix = "element_";
     const auto item_list = m_itemhandler.items();
 
-    for (const auto& item : item_list) {
-        const auto qobj = qvariant_cast<AbstractItem*>(item->property("item"));
+    for (const auto &item : item_list) {
+        const auto qobj = qvariant_cast<AbstractItem *>(item->property("item"));
 
         const auto json_element = qobj->toJson();
         save_json[element_prefix + QString::number(count)] = json_element;
@@ -76,24 +80,24 @@ void MainWindowHandler::save(const QVariant& file)
     m_savefile_handler.saveJSON(save_fileinfo.fileName(), save_json);
 }
 
-void MainWindowHandler::load(const QVariant& file)
+void MainWindowHandler::load(const QVariant &file)
 {
     QFileInfo load_fileinfo(file.toUrl().toLocalFile());
     QJsonDocument loadDoc = m_savefile_handler.loadJSON(load_fileinfo);
 
     QJsonObject json = loadDoc.object();
-    foreach (const QString& elementKey, json.keys()) {
+    foreach (const QString &elementKey, json.keys()) {
         auto element = json[elementKey].toObject();
 
         QQmlComponent component(m_qml_engine, QUrl(element["item.file"].toString()));
 
         auto elementProperties = element.toVariantMap();
         elementProperties.insert("parent", QVariant::fromValue(m_qml_creation_area));
-        QObject* comp = component.createWithInitialProperties(elementProperties);
+        QObject *comp = component.createWithInitialProperties(elementProperties);
         if (!comp) {
             qWarning("comp not found!");
         }
-        QQuickItem* item = qobject_cast<QQuickItem*>(comp);
+        QQuickItem *item = qobject_cast<QQuickItem *>(comp);
         if (!item) {
             qWarning("item  not found!");
         }
@@ -102,12 +106,12 @@ void MainWindowHandler::load(const QVariant& file)
     }
 }
 
-void MainWindowHandler::addItem(QQuickItem* quick_item)
+void MainWindowHandler::addItem(QQuickItem *quick_item)
 {
     m_itemhandler.addItem(quick_item);
 }
 
-void MainWindowHandler::removeItem(QQuickItem* quick_item)
+void MainWindowHandler::removeItem(QQuickItem *quick_item)
 {
     m_itemhandler.removeItem(quick_item);
 }
@@ -135,6 +139,19 @@ int MainWindowHandler::getRowByItemName(QVariant name)
     return itemList.at(0)->row();
 }
 
+void MainWindowHandler::updateProjectSettings(QVariantList newProjectSettings)
+{
+    if (newProjectSettings.size() != 3) {
+        qCCritical(mainwindow_handler)
+            << "Internal error. Wrong number of project settings delivered.";
+        return;
+    }
+
+    setPixelWidth(newProjectSettings[0].toInt());
+    setPixelHeight(newProjectSettings[1].toInt());
+    setFPS(newProjectSettings[2].toInt());
+}
+
 void MainWindowHandler::clearAllItems()
 {
     m_itemhandler.clear();
@@ -143,4 +160,69 @@ void MainWindowHandler::clearAllItems()
 void MainWindowHandler::currentRowChanged(const int row)
 {
     m_itemhandler.setCurrentRow(row);
+}
+
+qint32 MainWindowHandler::pixelWidth() const
+{
+    return m_renderer.projectSettings().width;
+}
+
+qint32 MainWindowHandler::pixelHeight() const
+{
+    return m_renderer.projectSettings().height;
+}
+
+qint32 MainWindowHandler::fps() const
+{
+    return m_renderer.projectSettings().fps;
+}
+
+void MainWindowHandler::setPixelWidth(qint32 new_pixel_width)
+{
+    auto projectSettings = m_renderer.projectSettings();
+
+    if (projectSettings.width == new_pixel_width) {
+        return;
+    }
+
+    const qreal ratio = new_pixel_width / qreal(projectSettings.width);
+    m_itemhandler.recalcItemsX(ratio);
+    m_itemhandler.recalcItemsWidth(ratio);
+
+    projectSettings.width = new_pixel_width;
+    m_renderer.setProjectSettings(projectSettings);
+
+    emit pixelWidthChanged(new_pixel_width);
+}
+
+void MainWindowHandler::setPixelHeight(qint32 new_pixel_height)
+{
+    auto projectSettings = m_renderer.projectSettings();
+
+    if (projectSettings.height == new_pixel_height) {
+        return;
+    }
+
+    const qreal ratio = new_pixel_height / qreal(projectSettings.height);
+    m_itemhandler.recalcItemsY(ratio);
+    m_itemhandler.recalcItemsHeight(ratio);
+
+    projectSettings.height = new_pixel_height;
+    m_renderer.setProjectSettings(projectSettings);
+
+    emit pixelHeightChanged(new_pixel_height);
+}
+
+void MainWindowHandler::setFPS(qint32 new_fps)
+{
+    auto projectSettings = m_renderer.projectSettings();
+
+    if (projectSettings.fps == new_fps) {
+        return;
+    }
+
+    projectSettings.fps = new_fps;
+    m_renderer.setProjectSettings(projectSettings);
+
+    emit pixelWidthChanged(new_fps);
 }

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -13,13 +13,17 @@
 
 class MainWindowHandler : public QObject
 {
-
     Q_OBJECT
 
+    Q_PROPERTY(qint32 pixel_width READ pixelWidth WRITE setPixelWidth NOTIFY pixelWidthChanged)
+    Q_PROPERTY(qint32 pixel_height READ pixelHeight WRITE setPixelHeight NOTIFY pixelHeightChanged)
+    Q_PROPERTY(qint32 fps READ fps WRITE setFPS NOTIFY fpsChanged)
+
 public:
-    MainWindowHandler(QQmlApplicationEngine *const engine);
+    MainWindowHandler();
 
     void init();
+    void initEngine(QQmlApplicationEngine *const engine);
 
 public slots:
 
@@ -34,9 +38,24 @@ public slots:
 
     int getRowByItemName(QVariant name);
 
+    void updateProjectSettings(QVariantList newProjectSettings);
+
     void clearAllItems();
 
     void currentRowChanged(const int row);
+
+    qint32 pixelWidth() const;
+    qint32 pixelHeight() const;
+    qint32 fps() const;
+
+    void setPixelWidth(qint32 new_pixel_width);
+    void setPixelHeight(qint32 new_pixel_height);
+    void setFPS(qint32 new_fps);
+
+signals:
+    void pixelWidthChanged(const qint32 new_pixel_width);
+    void pixelHeightChanged(const qint32 new_pixel_height);
+    void fpsChanged(const qint32 new_fps);
 
 private:
     QQmlApplicationEngine *m_qml_engine;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,9 +16,10 @@ int main(int argc, char* argv[])
 
     QGuiApplication app(argc, argv);
 
+    MainWindowHandler main_window;
     QQmlApplicationEngine engine;
 
-    MainWindowHandler main_window(&engine);
+    main_window.initEngine(&engine);
 
     const QUrl url("qrc:/qt/qml/cwa/mva/app/qml/Main.qml");
     QObject::connect(
@@ -30,8 +31,4 @@ int main(int argc, char* argv[])
     main_window.init();
 
     return app.exec();
-
-    // TODO: When quitting program crashes in Linux with
-    // malloc_consolidate(): unaligned fastbin chunk detected
-    // Maybe it has sth to do with my library structure
 }

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -16,6 +16,8 @@ ApplicationWindow {
     height: 600
     title: qsTr("mathvizanimator")
 
+    font.pointSize: 14
+
     minimumHeight: 500
     minimumWidth: 1200
 
@@ -83,6 +85,120 @@ ApplicationWindow {
         }
     }
 
+    Popup {
+        id: projectSettingsPopup
+        anchors.centerIn: parent
+        modal: true
+        focus: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        padding: 12
+
+        property list<int> projectData: [widthInputField.text, heightInputField.text, fpsInputField.text]
+
+        ColumnLayout {
+            id: mainLayout
+
+            anchors.fill: parent
+            Layout.alignment: Qt.AlignHCenter
+
+            spacing: 40
+
+            GridLayout {
+
+                columns: 2
+
+                rowSpacing: 20
+                columnSpacing: 20
+
+                Label {
+                    text: qsTr("Width (px):")
+
+                    Layout.alignment: Qt.AlignRight
+
+                    horizontalAlignment: Text.AlignRight
+                }
+
+                TextField {
+                    id: widthInputField
+
+                    text: main_window.pixel_width
+
+                    horizontalAlignment: TextInput.AlignRight
+
+                    validator: IntValidator {
+                        bottom: 50
+                        top: 4096
+                    }
+                }
+
+                Label {
+                    text: qsTr("Height (px):")
+
+                    Layout.alignment: Qt.AlignRight
+                    horizontalAlignment: Text.AlignRight
+                }
+
+                TextField {
+                    id: heightInputField
+
+                    text: main_window.pixel_height
+
+                    horizontalAlignment: TextInput.AlignRight
+
+                    validator: IntValidator {
+                        bottom: 50
+                        top: 2160
+                    }
+                }
+
+                Label {
+                    text: qsTr("fps:")
+
+                    Layout.alignment: Qt.AlignRight
+
+                    horizontalAlignment: Text.AlignRight
+                }
+
+                TextField {
+                    id: fpsInputField
+
+                    text: main_window.fps
+
+                    horizontalAlignment: TextInput.AlignRight
+
+                    validator: IntValidator {
+                        bottom: 1
+                        top: 120
+                    }
+                }
+            }
+
+            Row {
+                spacing: 10
+
+                Layout.alignment: Qt.AlignRight
+
+                Button {
+                    text: qsTr("Save")
+                    Layout.alignment: Qt.AlignHCenter
+
+                    // TODO: Validate data before sending, validators themselves are not enough
+                    onClicked: {
+                        main_window.updateProjectSettings(
+                                    projectSettingsPopup.projectData)
+                        projectSettingsPopup.close()
+                    }
+                }
+                Button {
+                    text: qsTr("Close")
+                    Layout.alignment: Qt.AlignHCenter
+
+                    onClicked: projectSettingsPopup.close()
+                }
+            }
+        }
+    }
+
     menuBar: MenuBar {
         anchors.leftMargin: 0
         anchors.rightMargin: 0
@@ -136,6 +252,11 @@ ApplicationWindow {
             Action {
                 text: qsTr("&Snapshot")
             }
+            Action {
+                text: qsTr("Pro&ject Settings")
+
+                onTriggered: projectSettingsPopup.open()
+            }
         }
         Menu {
             title: qsTr("&Help")
@@ -188,16 +309,13 @@ ApplicationWindow {
             Item {
                 id: dropAreaContainer
 
-                property real aimedRatio: 768 / 1024
+                property real aimedRatio: main_window.pixel_height / main_window.pixel_width
 
                 property bool parentIsLarge: parentRatio > aimedRatio
-                property double parentRatio: parent.height / parent.width
+                property real parentRatio: parent.height / parent.width
+                property real availableWidth: parentIsLarge ? parent.width : height / aimedRatio
 
-                anchors.horizontalCenter: dropRectangle.horizontalCenter
-                anchors.verticalCenter: dropRectangle.verticalCenter
-
-                height: parentIsLarge ? width * aimedRatio : parent.height
-                width: parentIsLarge ? parent.width : height / aimedRatio
+                anchors.fill: parent
 
                 DropArea {
                     id: creationArea
@@ -206,9 +324,9 @@ ApplicationWindow {
                     property var abstractItem: null
                     property var abstractComponent: null
 
-                    property double baseWidth: 1024
+                    property double baseWidth: main_window.pixel_width
                     property double baseHeight: baseWidth * dropAreaContainer.aimedRatio
-                    property double scaleFactor: parent.width / baseWidth
+                    property double scaleFactor: dropAreaContainer.availableWidth / baseWidth
 
                     signal itemAdded(Item item)
 


### PR DESCRIPTION
Add a small window to set project settings for width, height and fps. The drop area window is automatically rescaled, as well as all items in it. Maybe an option should be added s.t. the user can decide to keep items position and aspect ratio.