### PR TITLE
Move from static to dynamic libs

### DIFF
--- a/libs/mva_gui/CMakeLists.txt
+++ b/libs/mva_gui/CMakeLists.txt
@@ -10,7 +10,7 @@ qt_policy(SET QTP0001 NEW)
 qt_standard_project_setup()
 
 qt_add_library(cwa.mva.gui
-    STATIC
+    SHARED
     include/private/logging.h
 
     src/logging.cpp
@@ -41,6 +41,7 @@ qt_add_qml_module(cwa.mva.gui
     DEPENDENCIES QtQuick
     OUTPUT_DIRECTORY cwa/mva/gui
     RESOURCES mva_gui_resources.qrc
+    NO_PLUGIN
 )
 
 target_link_libraries(cwa.mva.gui
@@ -58,7 +59,6 @@ target_include_directories(cwa.mva.gui
 )
 
 add_library(mva::gui ALIAS cwa.mva.gui)
-add_library(mva::guiplugin ALIAS cwa.mva.guiplugin)
 
 # TODO: Add these files to a user path, so that they can be changed by the user
 # Currently they are provided by a resource file

--- a/libs/mva_gui/tests/CMakeLists.txt
+++ b/libs/mva_gui/tests/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(
     PRIVATE Qt6::QuickTest
     PRIVATE Qt6::Qml
     PRIVATE mva::gui
-    PRIVATE mva::guiplugin
 )
 
 target_link_libraries(
@@ -30,7 +29,6 @@ target_link_libraries(
     PRIVATE Qt6::QuickTest
     PRIVATE Qt6::Qml
     PRIVATE mva::gui
-    PRIVATE mva::guiplugin
 )
 
 target_link_libraries(
@@ -38,7 +36,6 @@ target_link_libraries(
     PRIVATE Qt6::QuickTest
     PRIVATE Qt6::Qml
     PRIVATE mva::gui
-    PRIVATE mva::guiplugin
 )
 
 target_link_libraries(
@@ -46,7 +43,6 @@ target_link_libraries(
     PRIVATE Qt6::QuickTest
     PRIVATE Qt6::Qml
     PRIVATE mva::gui
-    PRIVATE mva::guiplugin
 )
 
 # Currently disabled for windows. Dunno why it don't work on github actions, locally

--- a/libs/mva_workflow/CMakeLists.txt
+++ b/libs/mva_workflow/CMakeLists.txt
@@ -28,7 +28,6 @@ target_link_libraries(workflow
     PUBLIC
         Qt6::Core
         mva::gui
-        mva::guiplugin
 )
 
 target_include_directories(workflow

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,6 @@ set_target_properties(mva-app PROPERTIES
 target_link_libraries(mva-app
     PRIVATE
         mva::gui
-        mva::guiplugin
         mva::workflow
 )
 


### PR DESCRIPTION
Instead of static, dynamic libs are now created. To get this working, the Keyword NO_PLUGIN was used in the CMake function qt_add_qml_module(...). Otherwise, a module plugin will be created. This should also work by loading this at runtime, but I'm not 100% sure how. This https://stackoverflow.com/questions/51022680/building-qt-qml-plugin-using-cmake could maybe be helpful there.