### PR TITLE
Rmeove latexmk package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,6 @@ jobs:
           packages: >-
             scheme-basic
             preview
-            latexmk
             standalone
             xcolor
             dvisvgm


### PR DESCRIPTION
Since the latex call is changed, the latexmk package is not longer needed.

Closes #57