### PR TITLE
Add FileDialog for rendering and snapshots

### DIFF
--- a/app/src/mainlogic.cpp
+++ b/app/src/mainlogic.cpp
@@ -92,20 +92,22 @@ void MainLogic::connectEngine() {
     return;
   }
 
-  QObject::connect(m_qml_creation_area, SIGNAL(itemAdded(QQuickItem *)), this,
-                   SLOT(addItem(QQuickItem *)));
+  // clang-format off
+  QObject::connect(m_qml_creation_area, SIGNAL(itemAdded(QQuickItem*)), this,
+                   SLOT(addItem(QQuickItem*)));
+  // clang-format on
 }
 
-void MainLogic::createSnapshot() {
+void MainLogic::createSnapshot(const QFileInfo &snapshot_file_info) {
   const auto item_list = getAbstractItemList();
   const auto snapshot = m_renderer.createImage(item_list);
 
-  snapshot.save("snapshot.png");
+  snapshot.save(snapshot_file_info.absoluteFilePath());
 }
 
-void MainLogic::renderVideo() {
+void MainLogic::renderVideo(const QFileInfo &video_file_info) {
   const auto item_list = getAbstractItemList();
-  m_renderer.render(item_list);
+  m_renderer.render(item_list, video_file_info);
 }
 
 void MainLogic::saveProject(const QFileInfo &save_file_info) {

--- a/app/src/mainlogic.h
+++ b/app/src/mainlogic.h
@@ -39,8 +39,8 @@ class MainLogic : public QObject {
   void connectEngine();
 
  private slots:
-  void createSnapshot();
-  void renderVideo();
+  void createSnapshot(const QFileInfo &snapshot_file_info);
+  void renderVideo(const QFileInfo &video_file_info);
 
   void saveProject(const QFileInfo &save_file_info);
   void loadProject(const QFileInfo &load_file_info);

--- a/app/tests/integration_tests/tst_menu_project.cpp
+++ b/app/tests/integration_tests/tst_menu_project.cpp
@@ -66,7 +66,7 @@ void MenuProjectIntegrationTest::renderProject() {
   QVERIFY(m_helper_functions->compareNumItems(2));
 
   const QString render_file =
-      QDir::current().absoluteFilePath("render_test.mp4");
+      TestHelperFunctions::absoluteFilePath("render_test_video.mp4");
   if (QFile::exists(render_file)) {
     QFile::remove(render_file);
   }
@@ -78,6 +78,15 @@ void MenuProjectIntegrationTest::renderProject() {
       m_helper_functions->getChild<QObject*>("MVARenderProjectAction");
   QMetaObject::invokeMethod(render_action_item, "trigger");
 
+  auto render_file_dialog =
+      m_helper_functions->getChild<QObject*>("MVARenderFileDialog");
+  QVERIFY(render_file_dialog->property("visible").toBool());
+
+  render_file_dialog->setProperty("selectedFile",
+                                  QVariant(QUrl::fromLocalFile(render_file)));
+  QMetaObject::invokeMethod(render_file_dialog, "simulateAccepted",
+                            Qt::DirectConnection);
+
   QVERIFY(finishedVideoRenderingSpy.wait(60000));
   QVERIFY(QFile::exists(render_file));
 }
@@ -88,7 +97,7 @@ void MenuProjectIntegrationTest::createSnapshot() {
   QVERIFY(m_helper_functions->compareNumItems(2));
 
   const QString snapshot_file =
-      QDir::current().absoluteFilePath("snapshot.png");
+      TestHelperFunctions::absoluteFilePath("snapshot.png");
   if (QFile::exists(snapshot_file)) {
     QFile::remove(snapshot_file);
   }
@@ -96,6 +105,15 @@ void MenuProjectIntegrationTest::createSnapshot() {
   auto snapshot_action_item =
       m_helper_functions->getChild<QObject*>("MVACreateSnapshotAction");
   QMetaObject::invokeMethod(snapshot_action_item, "trigger");
+
+  auto snapshot_file_dialog =
+      m_helper_functions->getChild<QObject*>("MVASnapshotFileDialog");
+  QVERIFY(snapshot_file_dialog->property("visible").toBool());
+
+  snapshot_file_dialog->setProperty(
+      "selectedFile", QVariant(QUrl::fromLocalFile(snapshot_file)));
+  QMetaObject::invokeMethod(snapshot_file_dialog, "simulateAccepted",
+                            Qt::DirectConnection);
 
   QVERIFY(
       QTest::qWaitFor([&]() { return QFile::exists(snapshot_file) == true; }));
@@ -120,14 +138,22 @@ void MenuProjectIntegrationTest::openProjectSettings() {
                                        SIGNAL(renderingVideoFinished()));
 
   const QString render_file =
-      QDir::current().absoluteFilePath("render_test.mp4");
+      TestHelperFunctions::absoluteFilePath("render_test_video.mp4");
   if (QFile::exists(render_file)) {
     QFile::remove(render_file);
   }
-
   auto render_action_item =
       m_helper_functions->getChild<QObject*>("MVARenderProjectAction");
   QMetaObject::invokeMethod(render_action_item, "trigger");
+
+  auto render_file_dialog =
+      m_helper_functions->getChild<QObject*>("MVARenderFileDialog");
+  QVERIFY(render_file_dialog->property("visible").toBool());
+
+  render_file_dialog->setProperty("selectedFile",
+                                  QVariant(QUrl::fromLocalFile(render_file)));
+  QMetaObject::invokeMethod(render_file_dialog, "simulateAccepted",
+                            Qt::DirectConnection);
 
   QVERIFY(finishedVideoRenderingSpy.wait(60000));
   QVERIFY(QFile::exists(render_file));

--- a/libs/mva_gui/include/windows/mainwindowhandler.h
+++ b/libs/mva_gui/include/windows/mainwindowhandler.h
@@ -43,8 +43,8 @@ class MainWindowHandler : public QObject {
 
  public slots:
 
-  void snapshot();
-  void render();
+  void snapshot(const QVariant &file);
+  void render(const QVariant &file);
 
   void newProject();
   void saveProject(const QVariant &file);
@@ -70,8 +70,8 @@ class MainWindowHandler : public QObject {
   void fpsChanged(const qint32 new_fps);
   void videoLengthChanged(const qint32 new_video_length);
 
-  void snapshotRequested();
-  void renderingRequested();
+  void snapshotRequested(const QFileInfo &snapshot_file_info);
+  void renderingRequested(const QFileInfo &video_file_info);
 
   void newProjectRequested();
   void saveProjectRequested(const QFileInfo &save_file_info);

--- a/libs/mva_gui/qml/MainWindow.qml
+++ b/libs/mva_gui/qml/MainWindow.qml
@@ -91,6 +91,40 @@ ApplicationWindow {
         }
     }
 
+    FileDialog {
+        id: renderFileDialog
+        objectName: "MVARenderFileDialog"
+
+        currentFolder: StandardPaths.standardLocations(
+                           StandardPaths.HomeLocation)[0]
+        fileMode: FileDialog.SaveFile
+        nameFilters: ["MP4 (*.mp4)"]
+
+        onAccepted: main_window.render(selectedFile)
+
+        // Necessary for integration testing
+        function simulateAccepted() {
+            accepted()
+        }
+    }
+
+    FileDialog {
+        id: snapshotFileDialog
+        objectName: "MVASnapshotFileDialog"
+
+        currentFolder: StandardPaths.standardLocations(
+                           StandardPaths.HomeLocation)[0]
+        fileMode: FileDialog.SaveFile
+        nameFilters: ["PNG (*.png)"]
+
+        onAccepted: main_window.snapshot(selectedFile)
+
+        // Necessary for integration testing
+        function simulateAccepted() {
+            accepted()
+        }
+    }
+
     Popup {
         id: aboutPopup
         anchors.centerIn: parent
@@ -324,14 +358,14 @@ ApplicationWindow {
                 objectName: "MVARenderProjectAction"
 
                 text: qsTr("&Render")
-                onTriggered: main_window.render()
+                onTriggered: renderFileDialog.open()
             }
             Action {
                 id: createSnapshotAction
                 objectName: "MVACreateSnapshotAction"
 
                 text: qsTr("&Snapshot")
-                onTriggered: main_window.snapshot()
+                onTriggered: snapshotFileDialog.open()
             }
             Action {
                 id: openProjectSettingsAction

--- a/libs/mva_gui/src/windows/mainwindowhandler.cpp
+++ b/libs/mva_gui/src/windows/mainwindowhandler.cpp
@@ -24,9 +24,15 @@
 
 MainWindowHandler::MainWindowHandler(QObject *parent) : QObject(parent) {}
 
-void MainWindowHandler::snapshot() { emit snapshotRequested(); }
+void MainWindowHandler::snapshot(const QVariant &file) {
+  QFileInfo snapshot_file_info(file.toUrl().toLocalFile());
+  emit snapshotRequested(snapshot_file_info);
+}
 
-void MainWindowHandler::render() { emit renderingRequested(); }
+void MainWindowHandler::render(const QVariant &file) {
+  QFileInfo video_file_info(file.toUrl().toLocalFile());
+  emit renderingRequested(video_file_info);
+}
 
 void MainWindowHandler::saveProject(const QVariant &file) {
   QFileInfo save_file_info(file.toUrl().toLocalFile());

--- a/libs/mva_gui/tests/windows/test_mainwindowhandler.cpp
+++ b/libs/mva_gui/tests/windows/test_mainwindowhandler.cpp
@@ -86,7 +86,15 @@ void TestMainWindowHandler::snapshotRequested() {
   QSignalSpy snapshotRequestedSpy(&main_window_handler,
                                   &MainWindowHandler::snapshotRequested);
 
-  main_window_handler.snapshot();
+  QUrl test_snapshot_file_url("file://some_path/video_file.mp4");
+  QFileInfo test_snapshot_file_info(test_snapshot_file_url.toLocalFile());
+  connect(&main_window_handler, &MainWindowHandler::renderingRequested, this,
+          [&test_snapshot_file_info](const QFileInfo& new_snapshot_file_info) {
+            QCOMPARE(test_snapshot_file_info.absoluteFilePath(),
+                     new_snapshot_file_info.absoluteFilePath());
+          });
+
+  main_window_handler.snapshot(QVariant(test_snapshot_file_url));
 
   QCOMPARE(snapshotRequestedSpy.count(), 1);
 }
@@ -96,7 +104,15 @@ void TestMainWindowHandler::renderingRequested() {
   QSignalSpy renderRequestedSpy(&main_window_handler,
                                 &MainWindowHandler::renderingRequested);
 
-  main_window_handler.render();
+  QUrl test_video_file_url("file://some_path/video_file.mp4");
+  QFileInfo test_video_file_info(test_video_file_url.toLocalFile());
+  connect(&main_window_handler, &MainWindowHandler::renderingRequested, this,
+          [&test_video_file_info](const QFileInfo& new_video_file_info) {
+            QCOMPARE(test_video_file_info.absoluteFilePath(),
+                     new_video_file_info.absoluteFilePath());
+          });
+
+  main_window_handler.render(QVariant(test_video_file_url));
 
   QCOMPARE(renderRequestedSpy.count(), 1);
 }

--- a/libs/mva_workflow/include/workflow/renderer.h
+++ b/libs/mva_workflow/include/workflow/renderer.h
@@ -49,14 +49,15 @@ class Renderer : public QObject {
   QImage createImage(const QList<AbstractItem*>& item_list) const;
 
  public slots:
-  void render(const QList<AbstractItem*>& item_list);
+  void render(const QList<AbstractItem*>& item_list,
+              const QFileInfo& video_file);
 
  signals:
   void finishedRendering(const QFileInfo& video_file);
 
  private slots:
   void renderingProcessStarted(const QList<AbstractItem*>& item_list);
-  void renderingProcessFinished(qint32 exitCode,
+  void renderingProcessFinished(const QFileInfo& video_file, qint32 exitCode,
                                 QProcess::ExitStatus exitStatus);
 
  private:

--- a/libs/mva_workflow/src/renderer.cpp
+++ b/libs/mva_workflow/src/renderer.cpp
@@ -24,7 +24,8 @@
 
 Renderer::Renderer(QObject* parent) : QObject{parent} {}
 
-void Renderer::render(const QList<AbstractItem*>& item_list) {
+void Renderer::render(const QList<AbstractItem*>& item_list,
+                      const QFileInfo& video_file) {
   QString program = "ffmpeg";
   QStringList arguments;
   arguments << "-y"
@@ -39,8 +40,7 @@ void Renderer::render(const QList<AbstractItem*>& item_list) {
             << "-"
             << "-an"
             << "-vcodec"
-            << "libx264"
-            << "render_test.mp4";
+            << "libx264" << video_file.absoluteFilePath();
 
   auto render_process =
       QSharedPointer<QProcess>(new RenderProcess(m_next_process_id, this));
@@ -50,7 +50,9 @@ void Renderer::render(const QList<AbstractItem*>& item_list) {
   connect(render_process.data(), &QProcess::started, this,
           [item_list, this] { renderingProcessStarted(item_list); });
   connect(render_process.data(), &QProcess::finished, this,
-          &Renderer::renderingProcessFinished);
+          [video_file, this](qint32 exitCode, QProcess::ExitStatus exitStatus) {
+            renderingProcessFinished(video_file, exitCode, exitStatus);
+          });
   connect(render_process.data(), &QProcess::readyRead, this,
           [this] {
             qCInfo(renderer)
@@ -78,12 +80,18 @@ void Renderer::renderingProcessStarted(const QList<AbstractItem*>& item_list) {
   qobject_cast<QProcess*>(sender())->closeWriteChannel();
 }
 
-void Renderer::renderingProcessFinished(qint32 exitCode,
+void Renderer::renderingProcessFinished(const QFileInfo& video_file,
+                                        qint32 exitCode,
                                         QProcess::ExitStatus exitStatus) {
   Q_UNUSED(exitCode)
 
-  qCDebug(renderer) << "Process finished with status: " << exitStatus;
-  emit finishedRendering(QFileInfo("render_test.mp4"));
+  qCInfo(renderer) << "Process finished with status: " << exitStatus;
+  if (exitStatus == QProcess::NormalExit) {
+    qCInfo(renderer) << "Video file rendered to "
+                     << video_file.absoluteFilePath();
+  }
+
+  emit finishedRendering(video_file);
 
   m_render_process_map.remove(qobject_cast<RenderProcess*>(sender())->id());
 }

--- a/libs/mva_workflow/tests/tst_renderer.cpp
+++ b/libs/mva_workflow/tests/tst_renderer.cpp
@@ -132,7 +132,11 @@ void TestRenderer::render_data() {
   QTest::addColumn<qint32>("width");
   QTest::addColumn<qint32>("fps");
   QTest::addColumn<qint32>("video_length");
+  QTest::addColumn<QFileInfo>("video_file");
   QTest::addColumn<QImage>("test_frame_image");
+
+  QFileInfo home_dir_video(QDir::home(), "test_video_home.mp4");
+  QFileInfo temp_dir_video(QDir::temp(), "test_video_temp.mp4");
 
   QImage default_frame("://test_images/test_frame_default.png");
   QImage mod_frame("://test_images/test_frame_mod.png");
@@ -142,8 +146,9 @@ void TestRenderer::render_data() {
   QTest::newRow("default_setup")
       << defaultProjectSettings.height << defaultProjectSettings.width
       << defaultProjectSettings.fps << defaultProjectSettings.video_length
-      << default_frame;
-  QTest::newRow("mod_values") << 750 << 1250 << 32 << 10 << mod_frame;
+      << home_dir_video << default_frame;
+  QTest::newRow("mod_values")
+      << 750 << 1250 << 32 << 10 << temp_dir_video << mod_frame;
 }
 
 void TestRenderer::render() {
@@ -151,6 +156,7 @@ void TestRenderer::render() {
   QFETCH(qint32, width);
   QFETCH(qint32, fps);
   QFETCH(qint32, video_length);
+  QFETCH(QFileInfo, video_file);
   QFETCH(QImage, test_frame_image);
 
   Renderer renderer;
@@ -197,8 +203,12 @@ void TestRenderer::render() {
   project_settings.fps = fps;
   project_settings.video_length = video_length;
 
+  if (QFile::exists(video_file.absoluteFilePath())) {
+    QFile(video_file.absoluteFilePath()).remove();
+  }
+
   renderer.setProjectSettings(project_settings);
-  renderer.render(m_item_list);
+  renderer.render(m_item_list, video_file);
 
   QVERIFY(spy.wait(60000));
 }
@@ -207,8 +217,9 @@ void TestRenderer::multipleRendering() {
   Renderer renderer;
 
   QSignalSpy spy(&renderer, &Renderer::finishedRendering);
+  QFileInfo home_dir_video(QDir::home(), "test_video_home.mp4");
 
-  renderer.render(m_item_list);
+  renderer.render(m_item_list, home_dir_video);
   QVERIFY(spy.wait(60000));
 
   auto parent_item = new QQuickItem();
@@ -242,7 +253,7 @@ void TestRenderer::multipleRendering() {
                  test_frame_image_multi);
       });
 
-  renderer.render(m_item_list);
+  renderer.render(m_item_list, home_dir_video);
   QVERIFY(spy.wait(60000));
 }
 


### PR DESCRIPTION
## Template

Fixes #13 

### Proposed changes

* A FileDialog appears to specify the file for the rendered video/snapshot

### Motivation behind changes

User should specify where to store the rendered video/snapshot and also the name of the file.

### Test plan

Integrations and UI tests are added accordingly.

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [x] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [x] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with MathVizAnimator

* [ ] The PR is proposed to proper branch

* [ ] There is reference to original bug report and related work

* [ ] There is accuracy test, performance test and test data in the repository,
if applicable

* [ ] The feature is well documented and sample code can be built with the project
CMake
