### PR TITLE
Remove unused files from latex rendering directly

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -5,6 +5,7 @@
     "**/.git/**",
     "**/.pnpm-lock.json",
     ".vscode",
+    ".clang-format",
     "megalinter",
     "package-lock.json",
     "report"

--- a/libs/mva_gui/include/items/textitem.h
+++ b/libs/mva_gui/include/items/textitem.h
@@ -64,6 +64,8 @@ class TextItem : public AbstractItem {
   void scaleTextChanged(const qreal new_scale_text);
 
  private:
+  void removeUnusedLatexFiles(const QString& hash);
+
   QFileInfo m_svg_file = QFileInfo("://templates/placeholder.svg");
   QString m_latex_source;
   qreal m_scale_text = 1.0;

--- a/libs/mva_gui/src/items/textitem.cpp
+++ b/libs/mva_gui/src/items/textitem.cpp
@@ -130,6 +130,7 @@ void TextItem::setLatexSource(const QString& newLatexSource) {
                                                     << latexFile.fileName());
   if (!latexmk_process.waitForFinished()) {
     qDebug() << "Make failed:" << latexmk_process.errorString();
+    removeUnusedLatexFiles(hash);
     return;
   }
 
@@ -140,8 +141,10 @@ void TextItem::setLatexSource(const QString& newLatexSource) {
                                                       << "-o" << hash + ".svg");
   if (!dvisvgm_process.waitForFinished()) {
     qDebug() << "Make failed:" << dvisvgm_process.errorString();
+    removeUnusedLatexFiles(hash);
     return;
   }
+  removeUnusedLatexFiles(hash);
 
   setSvgFile(svgFile);
 
@@ -170,4 +173,12 @@ AbstractItem::EditableProperties TextItem::editableProperties() const {
   abstractList.abstract_item_properties.append("scaleText");
 
   return abstractList;
+}
+
+void TextItem::removeUnusedLatexFiles(const QString& hash) {
+  QList<QString> file_appendices{".aux", ".dvi", ".log"};
+
+  for (const auto& appendix : file_appendices) {
+    QFile::remove(m_svg_location.absoluteFilePath(hash + appendix));
+  }
 }

--- a/libs/mva_gui/tests/items/textitem/tst_textitem.cpp
+++ b/libs/mva_gui/tests/items/textitem/tst_textitem.cpp
@@ -75,8 +75,8 @@ void TestTextItem::latexRenderTest() {
   const QDir appPath =
       QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
 
-  auto svg_file =
-      QFile(appPath.absoluteFilePath("0f35255d1355d2c32390101bf57ff4d0.svg"));
+  const QString hash = "0f35255d1355d2c32390101bf57ff4d0";
+  auto svg_file = QFile(appPath.absoluteFilePath(hash + ".svg"));
   if (svg_file.exists()) {
     QVERIFY(svg_file.remove());
   }
@@ -88,6 +88,9 @@ void TestTextItem::latexRenderTest() {
   QCOMPARE(m_text_item.getLatexSource(), test_latex);
   QCOMPARE(m_text_item.getSvgFile(),
            appPath.absoluteFilePath(svg_file.fileName()));
+  QVERIFY(!QFile::exists(appPath.absoluteFilePath(hash + ".aux")));
+  QVERIFY(!QFile::exists(appPath.absoluteFilePath(hash + ".dvi")));
+  QVERIFY(!QFile::exists(appPath.absoluteFilePath(hash + ".log")));
 }
 
 void TestTextItem::paintTest() {


### PR DESCRIPTION
Fixes #68 

### Proposed changes

* There are unused latex file after rendering a textitem: *.dvi, *.log, *.aux. They will now be removed automatically.

### Motivation behind changes

It is not necessary to file up the users system with junk files.

### Test plan

Adapt textitem unittest. It checks now for this files.

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [x] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [x] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with MathVizAnimator

* [x] The PR is proposed to proper branch

* [x] There is reference to original bug report and related work

* [x] There is accuracy test, performance test and test data in the repository,
if applicable

