### PR TITLE
Apply Material Sytle to App, Replace Popups with Dialogs

### DIFF
--- a/libs/mva_gui/qml/MainWindow.qml
+++ b/libs/mva_gui/qml/MainWindow.qml
@@ -133,7 +133,7 @@ ApplicationWindow {
 
     Dialog {
         id: projectSettingsDialog
-        objectName: "MVAProjectSettingsPopup"
+        objectName: "MVAProjectSettingsDialog"
 
         anchors.centerIn: parent
         padding: 12
@@ -143,6 +143,12 @@ ApplicationWindow {
         title: qsTr("Project Settings")
 
         property list<int> projectData: [widthInputField.text, heightInputField.text, fpsInputField.text, videoLengthInputField.text]
+
+        // Necessary for integration testing, close() is needed for macOS test, it crashes (segmentation fault) otherwise
+        function simulateAccepted() {
+            accepted()
+            close()
+        }
 
         ColumnLayout {
             id: mainLayout
@@ -584,26 +590,31 @@ ApplicationWindow {
                             model: property_model
                         }
 
-                        delegate: Label {
-                            required property bool current
-
+                        delegate: Rectangle {
                             id: mPropertyTableDelegate
 
-                            text: display
-                            padding: 10
+                            required property bool editing
 
-                            color: row === mPropertyTable.currentRow ? palette.highlightedText : palette.text
-                            background: Rectangle {
+                            implicitWidth: 100
+                            implicitHeight: 50
+
+                            color: row === mPropertyTable.currentRow ? palette.highlight : (mPropertyTable.alternatingRows && row % 2 !== 0 ? palette.alternateBase : palette.base)
+
+                            Label {
                                 anchors.fill: parent
+                                anchors.margins: 5
+                                verticalAlignment: TextInput.AlignVCenter
 
-                                color: row === mPropertyTable.currentRow ? palette.highlight : (mPropertyTable.alternatingRows && row % 2 !== 0 ? palette.alternateBase : palette.base)
+                                text: display
+                                visible: !editing
+
+                                color: row === mPropertyTable.currentRow ? palette.highlightedText : palette.text
                             }
 
                             TableView.editDelegate: TextField {
                                 anchors.fill: parent
+
                                 text: display
-                                horizontalAlignment: TextInput.AlignHCenter
-                                verticalAlignment: TextInput.AlignVCenter
                                 Component.onCompleted: selectAll()
 
                                 TableView.onCommit: {

--- a/libs/mva_gui/qml/MainWindow.qml
+++ b/libs/mva_gui/qml/MainWindow.qml
@@ -18,6 +18,7 @@
 import QtQuick
 import QtQuick.Window
 import QtQuick.Controls
+import QtQuick.Controls.Material
 import QtQuick.Layouts
 import QtQuick.Dialogs
 
@@ -34,6 +35,8 @@ ApplicationWindow {
     title: qsTr("mathvizanimator")
 
     font.pointSize: 14
+
+    Material.theme: Material.System
 
     minimumHeight: 500
     minimumWidth: 1200
@@ -91,97 +94,53 @@ ApplicationWindow {
         }
     }
 
-    Popup {
-        id: aboutPopup
+    Dialog {
+        id: aboutDialog
         anchors.centerIn: parent
-        modal: true
-        focus: true
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
-        width: 500
+        standardButtons: Dialog.Ok
 
-        background: Rectangle {
-            radius: 10
-            color: palette.window
-
-            border.color: palette.shadow
-            border.width: 2
-        }
+        title: qsTr("MathVizAnimator 0.0.1")
 
         ColumnLayout {
-            anchors.fill: parent
-            spacing: 0
+            spacing: 25
+            width: parent.width
+            Layout.alignment: Qt.AlignHCenter
 
-            Rectangle {
-                radius: 10
-                height: 60
-                width: parent.width
-
-                border.color: palette.shadow
-                border.width: 2
-
-                color: palette.dark
-
-                Label {
-                    anchors.centerIn: parent
-                    text: "MathVizAnimator 0.0.1"
-
-                    font.pointSize: 22
-                }
-            }
-
-            Item {
-                height: 25
-            }
-
-            ColumnLayout {
-                spacing: 25
-                width: parent.width
+            Label {
+                text: qsTr("MathVizAnimator developed by CodingWithMagga. \nThe links below may be interesting for you.")
                 Layout.alignment: Qt.AlignHCenter
+                horizontalAlignment: Text.AlignHCenter
 
-                Label {
-                    text: qsTr("MathVizAnimator developed by CodingWithMagga. \nThe links below may be interesting for you.")
-                    Layout.alignment: Qt.AlignHCenter
-                    horizontalAlignment: Text.AlignHCenter
+                width: parent.width
 
-                    width: parent.width
+                wrapMode: Text.WordWrap
+            }
 
-                    wrapMode: Text.WordWrap
-                }
-
-                Label {
-                    text: qsTr('<a href="https://github.com/codingwithmagga/mathvizanimator">github</a> (english) <br>\
+            Label {
+                text: qsTr('<a href="https://github.com/codingwithmagga/mathvizanimator">github</a> (english) <br>\
 <a href="https://codingwithmagga.com">Website</a> (german) <br>\
 <a href="https://www.youtube.com/channel/UCjlzef-PolOD__Q1VMWznqw">YouTube</a> (german) ')
 
-                    Layout.alignment: Qt.AlignHCenter
+                Layout.alignment: Qt.AlignHCenter
 
-                    linkColor: palette.windowText
-
-                    onLinkActivated: function (link) {
-                        Qt.openUrlExternally(link)
-                    }
-                }
-
-                Button {
-                    text: qsTr("Close")
-                    Layout.alignment: Qt.AlignHCenter
-
-                    onClicked: aboutPopup.close()
+                onLinkActivated: function (link) {
+                    Qt.openUrlExternally(link)
                 }
             }
         }
     }
 
-    Popup {
-        id: projectSettingsPopup
+    Dialog {
+        id: projectSettingsDialog
         objectName: "MVAProjectSettingsPopup"
 
         anchors.centerIn: parent
-        modal: true
-        focus: true
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
         padding: 12
+
+        standardButtons: Dialog.Ok | Dialog.Cancel
+
+        title: qsTr("Project Settings")
 
         property list<int> projectData: [widthInputField.text, heightInputField.text, fpsInputField.text, videoLengthInputField.text]
 
@@ -244,7 +203,7 @@ ApplicationWindow {
                 }
 
                 Label {
-                    text: qsTr("fps:")
+                    text: qsTr("Frames per Second (fps):")
 
                     Layout.alignment: Qt.AlignRight
 
@@ -287,36 +246,11 @@ ApplicationWindow {
                     }
                 }
             }
-
-            Row {
-                spacing: 10
-
-                Layout.alignment: Qt.AlignRight
-
-                Button {
-                    id: saveProjectSettingsButton
-                    objectName: "MVASaveProjectSettingsButton"
-
-                    text: qsTr("Save")
-                    Layout.alignment: Qt.AlignHCenter
-
-                    // TODO(codingwithmagga): Validate data before sending, validators themselves are not enough
-                    onClicked: {
-                        main_window.updateProjectSettings(
-                                    projectSettingsPopup.projectData)
-                        projectSettingsPopup.close()
-                    }
-                }
-                Button {
-                    id: cancelProjectSettingsButton
-                    objectName: "MVACancelProjectSettingsButton"
-
-                    text: qsTr("Cancel")
-                    Layout.alignment: Qt.AlignHCenter
-
-                    onClicked: projectSettingsPopup.close()
-                }
-            }
+        }
+        // TODO(codingwithmagga): Validate data before sending, validators themselves are not enough
+        onAccepted: {
+            main_window.updateProjectSettings(projectSettingsDialog.projectData)
+            projectSettingsDialog.close()
         }
     }
 
@@ -325,10 +259,6 @@ ApplicationWindow {
 
         anchors.leftMargin: 0
         anchors.rightMargin: 0
-
-        background: Rectangle {
-            color: palette.dark
-        }
 
         Menu {
             id: file_menu
@@ -391,7 +321,7 @@ ApplicationWindow {
                 objectName: "MVAOpenProjectSettingsAction"
 
                 text: qsTr("Pro&ject Settings")
-                onTriggered: projectSettingsPopup.open()
+                onTriggered: projectSettingsDialog.open()
             }
             Action {
                 id: openSVGFolderAction
@@ -406,7 +336,7 @@ ApplicationWindow {
             Action {
                 text: qsTr("&About")
 
-                onTriggered: aboutPopup.open()
+                onTriggered: aboutDialog.open()
             }
         }
     }
@@ -447,7 +377,7 @@ ApplicationWindow {
             Layout.fillWidth: true
             Layout.margins: 20
 
-            color: palette.dark
+            color: Material.color(Material.Grey)
 
             // TODO(codingwithmagga): Put this in a reusable component
             Item {
@@ -535,7 +465,7 @@ ApplicationWindow {
         Rectangle {
             id: mObjectsListViewRect
 
-            color: palette.dark
+            color: Material.color(Material.Grey)
             Layout.minimumWidth: 150
             Layout.preferredWidth: 300
             Layout.maximumWidth: 400

--- a/libs/mva_workflow/src/itemhandler.cpp
+++ b/libs/mva_workflow/src/itemhandler.cpp
@@ -258,7 +258,7 @@ void ItemHandler::propertyDataChanged(const QModelIndex& topLeft,
   }
 
   // Update item
-  auto item = m_item_model.itemFromIndex(m_item_selection_model.currentIndex());
+  auto item = m_item_model.item(m_item_selection_model.currentIndex().row());
   auto quick_item = item->data(ItemRoles::QUICKITEM).value<QQuickItem*>();
   auto itemExtract = extractAbstractItem(
       item->data(ItemRoles::QUICKITEM).value<QQuickItem*>());


### PR DESCRIPTION
Fixes #75 

### Proposed changes

* Material Style is now used
* Replace Popups with Dialogs

### Motivation behind changes

The UI looks much better now using the material style. Replacing Popups with Dialogs works better with the material style (and looks better) and less code is needed.

### Test plan

Just UI changes, no additional tests needed.

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [x] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [x] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with MathVizAnimator

* [x] The PR is proposed to proper branch

* [x] There is reference to original bug report and related work

* [x] There is accuracy test, performance test and test data in the repository,
if applicable
