### PR TITLE
Use configure_file(...) fct for qml test file copy operation

### DIFF
--- a/libs/mva_gui/tests/CMakeLists.txt
+++ b/libs/mva_gui/tests/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(
 )
 
 # Copy qml test files to build folder. Using configure_file(...) because it creates a dependency
-# on the source file, so CMake will be re-run if it changes. This is a nice behaviour, since a change
+# on the source file, so CMake will be re-run if it changes. This is a nice behavior, since a change
 # in the qml test file is not detected by the compiler.
 configure_file(qml/tst_circleitem.qml tst_circleitem.qml COPYONLY)
 configure_file(qml/tst_rectangleitem.qml tst_rectangleitem.qml COPYONLY)


### PR DESCRIPTION
Fixes #49 

### Proposed changes

* Keep configure_file(...) for coping qml test files and update comment

### Motivation behind changes

Using configure_file(...) because it creates a dependency on the source file, so CMake will be re-run if it changes. This is a nice behaviour, since a change in the qml test file is not detected by the compiler.

### Test plan

Tests are running as usual.

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [x] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [x] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with MathVizAnimator

* [x] The PR is proposed to proper branch

* [x] There is reference to original bug report and related work

* [x] There is accuracy test, performance test and test data in the repository,
if applicable