### PR TITLE
Create a reusable Text Editor, use it in TextItem

### DIFF
--- a/libs/mva_gui/CMakeLists.txt
+++ b/libs/mva_gui/CMakeLists.txt
@@ -40,6 +40,7 @@ qt_add_qml_module(cwa.mva.gui
         qml/items/MVAText.qml
         qml/items/MVAMouseArea.qml
         qml/items/MVASurroundingRectangle.qml
+        qml/windows/TextDialog.qml
     SOURCES
         include/items/abstractitem.h
         include/items/circleitem.h

--- a/libs/mva_gui/qml/items/MVAText.qml
+++ b/libs/mva_gui/qml/items/MVAText.qml
@@ -56,67 +56,7 @@ BasicItem {
         }
     }
 
-    Popup {
+    TextDialog {
         id: createText
-
-        anchors.centerIn: Overlay.overlay
-        modal: true
-        focus: true
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-
-        width: 400
-
-        background: Rectangle {
-            color: palette.window
-        }
-
-        ColumnLayout {
-            anchors.fill: parent
-            spacing: 20
-
-            ScrollView {
-                id: view
-
-                Layout.preferredHeight: 200
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-
-                anchors.margins: 60
-
-                background: Rectangle {
-                    color: palette.base
-                }
-
-                focus: true
-
-                TextArea {
-                    id: latexTextArea
-                    focus: true
-
-                    text: ""
-                }
-            }
-
-            RowLayout {
-                Layout.alignment: Qt.AlignRight
-
-                spacing: 10
-
-                Button {
-                    text: qsTr("Close")
-
-                    onClicked: createText.close()
-                }
-
-                Button {
-                    text: qsTr("Accept")
-
-                    onClicked: {
-                        textItem.latexSource = latexTextArea.text
-                        createText.close()
-                    }
-                }
-            }
-        }
     }
 }

--- a/libs/mva_gui/qml/windows/TextDialog.qml
+++ b/libs/mva_gui/qml/windows/TextDialog.qml
@@ -1,0 +1,53 @@
+import QtQuick 2.15
+import QtQuick.Layouts
+import QtQuick.Controls
+
+Dialog {
+    id: createText
+
+    anchors.centerIn: Overlay.overlay
+    modal: true
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+    title: "Text Editor"
+
+    width: 400
+    height: 200
+
+    standardButtons: Dialog.Ok | Dialog.Cancel
+
+    onAccepted: {
+        textItem.latexSource = latexTextArea.text
+        createText.close()
+    }
+    onRejected: createText.close()
+
+    background: Rectangle {
+        color: palette.dark
+    }
+
+    ScrollView {
+        id: view
+
+        anchors.fill: parent
+
+        clip: true
+        focus: true
+
+        TextArea {
+            id: latexTextArea
+            focus: true
+
+            placeholderText: qsTr("Enter LaTeX text")
+
+            text: ""
+
+            cursorPosition: 0
+            cursorVisible: true
+
+            background: Rectangle {
+                color: palette.dark
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #20

### Proposed changes

* Make a reusable Text Editor
* Use it for TextItem Latex text

### Motivation behind changes

Old Editor was ugly and not reusable

### Test plan

CI should work
Developer tests were successful

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [x] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [x] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with MathVizAnimator

* [x] The PR is proposed to proper branch

* [x] There is reference to original bug report and related work

* [x] There is accuracy test, performance test and test data in the repository,
if applicable
