### PR TITLE
Fixed textitem bug and add test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: (1) Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         timeout-minutes: 5
         with:
           fetch-depth: 0
@@ -80,7 +80,7 @@ jobs:
           pip install gcovr==6.0
 
       - name: (3.4) Setup ffmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v2
+        uses: FedericoCarboni/setup-ffmpeg@v3
         timeout-minutes: 5
         id: setup-ffmpeg
 

--- a/app/src/mainlogic.cpp
+++ b/app/src/mainlogic.cpp
@@ -41,6 +41,7 @@ MainLogic::MainLogic(QObject* parent)
     connect(&m_mainwindowhandler, &MainWindowHandler::removeAnimationRequested, &m_itemhandler,
         &ItemHandler::removeAnimation);
     connect(&m_mainwindowhandler, &MainWindowHandler::itemClicked, &m_itemhandler, &ItemHandler::setCurrentItem);
+    connect(&m_mainwindowhandler, &MainWindowHandler::propertyChanged, &m_itemhandler, &ItemHandler::changeProperty);
     connect(&m_mainwindowhandler, &MainWindowHandler::newProjectRequested, &m_itemhandler, &ItemHandler::clear);
     connect(&m_mainwindowhandler, &MainWindowHandler::addAnimationSignal, &m_itemhandler, &ItemHandler::addAnimation);
 
@@ -90,8 +91,8 @@ void MainLogic::connectEngine()
     }
 
     // clang-format off
-      QObject::connect(m_qml_creation_area, SIGNAL(itemAdded(QQuickItem*)), &m_mainwindowhandler,
-                       SLOT(addItem(QQuickItem*)));
+    QObject::connect(m_qml_creation_area, SIGNAL(itemAdded(QQuickItem*)), &m_mainwindowhandler,
+                     SLOT(addItem(QQuickItem*)));
     // clang-format on
 }
 

--- a/app/tests/CMakeLists.txt
+++ b/app/tests/CMakeLists.txt
@@ -23,10 +23,16 @@ qt_add_executable(int_animation_test
     integration_tests/test_helper_functions.h
     integration_tests/test_helper_functions.cpp
 )
+qt_add_executable(int_user_interaction_test
+    integration_tests/tst_user_interaction.cpp
+    integration_tests/test_helper_functions.h
+    integration_tests/test_helper_functions.cpp
+)
 
 add_test(NAME int_menu_file_test COMMAND int_menu_file_test)
 add_test(NAME int_menu_project_test COMMAND int_menu_project_test)
 add_test(NAME int_animation_test COMMAND int_animation_test)
+add_test(NAME int_user_interaction_test COMMAND int_user_interaction_test)
 
 target_link_libraries(
     int_menu_file_test
@@ -43,6 +49,12 @@ target_link_libraries(
 )
 target_link_libraries(
     int_animation_test
+    PRIVATE Qt::Test
+    PRIVATE Qt6::Quick
+    PRIVATE mva::applib
+)
+target_link_libraries(
+    int_user_interaction_test
     PRIVATE Qt::Test
     PRIVATE Qt6::Quick
     PRIVATE mva::applib

--- a/app/tests/integration_tests/test_helper_functions.cpp
+++ b/app/tests/integration_tests/test_helper_functions.cpp
@@ -46,6 +46,7 @@ TestHelperFunctions::TestHelperFunctions(const QSharedPointer<QQmlApplicationEng
     m_property_table_view = root_objects.first()->findChild<QObject*>("MVAPropertyTable");
     m_animations_table_view = root_objects.first()->findChild<QObject*>("MVAAnimationTable");
     m_creation_area = root_objects.first()->findChild<QQuickItem*>("MVACreationArea");
+    m_time_slider = root_objects.first()->findChild<QQuickItem*>("MVATimeSlider");
 
     auto items_model = m_project_items_table_view->property("model");
     m_project_items_model = qvariant_cast<QStandardItemModel*>(items_model);
@@ -74,20 +75,32 @@ void TestHelperFunctions::dragAndDropItem(const QPoint& start_pos, const QPoint&
 {
     const QPoint minimum_drag_distance(20, 20);
 
-    QTest::mousePress(m_quick_window, Qt::LeftButton, Qt::NoModifier, start_pos);
-    QTest::mouseMove(m_quick_window, start_pos + minimum_drag_distance);
-    QTest::mouseRelease(m_quick_window, Qt::LeftButton, Qt::NoModifier, end_pos);
+    QTest::mousePress(m_quick_window, Qt::LeftButton, Qt::NoModifier, start_pos, 20);
+    QTest::mouseMove(m_quick_window, start_pos + minimum_drag_distance, 20);
+    QTest::mouseRelease(m_quick_window, Qt::LeftButton, Qt::NoModifier, end_pos, 20);
 }
 
 void TestHelperFunctions::clickItem(QQuickItem* quick_item, Qt::MouseButton mouse_button)
 {
-    auto oPoint = quick_item->mapToScene(QPoint(0, 0)).toPoint();
+    auto quick_item_center = quick_item->mapToScene(QPoint(0, 0)).toPoint();
 
-    oPoint.rx() += quick_item->width() / 2;
-    oPoint.ry() += quick_item->height() / 2;
+    quick_item_center.rx() += quick_item->width() / 2;
+    quick_item_center.ry() += quick_item->height() / 2;
 
-    QTest::mouseClick(m_quick_window, mouse_button, Qt::NoModifier, oPoint);
+    QTest::mouseClick(m_quick_window, mouse_button, Qt::NoModifier, quick_item_center);
 }
+
+void TestHelperFunctions::moveItem(QQuickItem* quick_item, const QPoint& move_dist)
+{
+    auto quick_item_center = quick_item->mapToScene(QPoint(0, 0)).toPoint();
+
+    quick_item_center.rx() += quick_item->width() / 2;
+    quick_item_center.ry() += quick_item->height() / 2;
+
+    dragAndDropItem(quick_item_center, quick_item_center + move_dist);
+}
+
+void TestHelperFunctions::changeTime(const qreal time) { m_time_slider->setProperty("value", time); }
 
 QSharedPointer<ItemObserver> TestHelperFunctions::getItemObserver(const qint32 item_number) const
 {

--- a/app/tests/integration_tests/test_helper_functions.cpp
+++ b/app/tests/integration_tests/test_helper_functions.cpp
@@ -87,7 +87,7 @@ void TestHelperFunctions::clickItem(QQuickItem* quick_item, Qt::MouseButton mous
 
 void TestHelperFunctions::moveItem(QQuickItem* quick_item, const QPoint& move_dist)
 {
-    dragAndDropItem(quick_item_center, itemCenter(quick_item) + move_dist);
+    dragAndDropItem(itemCenter(quick_item), itemCenter(quick_item) + move_dist);
 }
 
 void TestHelperFunctions::changeTime(const qreal time) { m_time_slider->setProperty("value", time); }

--- a/app/tests/integration_tests/test_helper_functions.cpp
+++ b/app/tests/integration_tests/test_helper_functions.cpp
@@ -82,22 +82,12 @@ void TestHelperFunctions::dragAndDropItem(const QPoint& start_pos, const QPoint&
 
 void TestHelperFunctions::clickItem(QQuickItem* quick_item, Qt::MouseButton mouse_button)
 {
-    auto quick_item_center = quick_item->mapToScene(QPoint(0, 0)).toPoint();
-
-    quick_item_center.rx() += quick_item->width() / 2;
-    quick_item_center.ry() += quick_item->height() / 2;
-
-    QTest::mouseClick(m_quick_window, mouse_button, Qt::NoModifier, quick_item_center);
+    QTest::mouseClick(m_quick_window, mouse_button, Qt::NoModifier, itemCenter(quick_item));
 }
 
 void TestHelperFunctions::moveItem(QQuickItem* quick_item, const QPoint& move_dist)
 {
-    auto quick_item_center = quick_item->mapToScene(QPoint(0, 0)).toPoint();
-
-    quick_item_center.rx() += quick_item->width() / 2;
-    quick_item_center.ry() += quick_item->height() / 2;
-
-    dragAndDropItem(quick_item_center, quick_item_center + move_dist);
+    dragAndDropItem(quick_item_center, itemCenter(quick_item) + move_dist);
 }
 
 void TestHelperFunctions::changeTime(const qreal time) { m_time_slider->setProperty("value", time); }
@@ -192,4 +182,14 @@ QString TestHelperFunctions::absoluteFilePath(const QString file_name)
     current_dir.cd(save_dir);
 
     return current_dir.absoluteFilePath(file_name);
+}
+
+QPoint TestHelperFunctions::itemCenter(QQuickItem* item) const
+{
+    auto item_center = item->mapToScene(QPoint(0, 0)).toPoint();
+
+    item_center.rx() += item->width() / 2;
+    item_center.ry() += item->height() / 2;
+
+    return item_center;
 }

--- a/app/tests/integration_tests/test_helper_functions.h
+++ b/app/tests/integration_tests/test_helper_functions.h
@@ -36,6 +36,9 @@ class TestHelperFunctions {
     void dragAndDropItem(const QPoint& start_pos, const QPoint& end_pos);
 
     void clickItem(QQuickItem* quick_item, Qt::MouseButton mouse_button = Qt::MouseButton::LeftButton);
+    void moveItem(QQuickItem* quick_item, const QPoint& move_dist);
+
+    void changeTime(const qreal time);
 
     QQuickWindow* rootWindow() const { return m_quick_window; }
     QObject* draggableItemListView() const { return m_draggable_item_list_view; }
@@ -79,6 +82,7 @@ class TestHelperFunctions {
     QStandardItemModel* m_property_model = Q_NULLPTR;
     QStandardItemModel* m_animations_model = Q_NULLPTR;
     QQuickItem* m_creation_area = Q_NULLPTR;
+    QQuickItem* m_time_slider = Q_NULLPTR;
 };
 
 #endif // APP_TESTS_INTEGRATION_TESTS_TEST_HELPER_FUNCTIONS_H_

--- a/app/tests/integration_tests/test_helper_functions.h
+++ b/app/tests/integration_tests/test_helper_functions.h
@@ -71,6 +71,8 @@ class TestHelperFunctions {
     static QString absoluteFilePath(const QString file_name);
 
   private:
+    QPoint itemCenter(QQuickItem* item) const;
+
     QSharedPointer<QQmlApplicationEngine> m_engine;
 
     QQuickWindow* m_quick_window = Q_NULLPTR;

--- a/app/tests/integration_tests/tst_user_interaction.cpp
+++ b/app/tests/integration_tests/tst_user_interaction.cpp
@@ -1,0 +1,70 @@
+/* mathvizanimator
+ * Copyright (C) 2023 codingwithmagga
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QTest>
+
+#include "main.h"
+#include "test_helper_functions.h"
+
+class UserInteractionTest : public QObject {
+    Q_OBJECT
+
+  private slots:
+    void init();
+
+    void moveItemChangeTime();
+
+    void cleanup();
+
+  private:
+    SetupMain::SetupObjects m_app_objects;
+    QSharedPointer<TestHelperFunctions> m_helper_functions;
+};
+
+void UserInteractionTest::init()
+{
+    m_app_objects = SetupMain::setupApp();
+
+    m_helper_functions = QSharedPointer<TestHelperFunctions>(new TestHelperFunctions(m_app_objects.engine));
+}
+
+void UserInteractionTest::moveItemChangeTime()
+{
+    const qint32 item_number = 0;
+    m_helper_functions->dragAndDropCurrentItem(QPoint(100, 100));
+    const auto basic_item = m_helper_functions->getQuickItem(item_number);
+    const auto previous_x = basic_item->x();
+    const auto previous_y = basic_item->y();
+
+    m_helper_functions->moveItem(basic_item, QPoint(50, 15));
+    m_helper_functions->changeTime(1.3);
+
+    QCOMPARE(basic_item->opacity(), 1.0);
+    QCOMPARE_NE(basic_item->x(), previous_x);
+    QCOMPARE_NE(basic_item->y(), previous_y);
+}
+
+void UserInteractionTest::cleanup()
+{
+    m_helper_functions.clear();
+
+    m_app_objects.engine.clear();
+    m_app_objects.mainlogic.clear();
+}
+
+QTEST_MAIN(UserInteractionTest)
+#include "tst_user_interaction.moc"

--- a/libs/mva_gui/include/windows/mainwindowhandler.h
+++ b/libs/mva_gui/include/windows/mainwindowhandler.h
@@ -58,6 +58,7 @@ class MainWindowHandler : public QObject {
 
     void itemClickedByUser(const QString& itemName);
     void setTimeByUser(const QVariant& time);
+    void propertyChangedByUser(const QString& item_name, const QByteArray& property, const QVariant& value);
 
     void updateProjectSettings(const QVariantList& new_project_settings);
     void updateProjectSettings(const QList<qint32>& new_project_settings);
@@ -89,6 +90,7 @@ class MainWindowHandler : public QObject {
     void itemAdded(BasicItem* item);
     void itemClicked(const QString& name);
     void timeChanged(const qreal time);
+    void propertyChanged(const QString& item_name, const QByteArray& property, const QVariant& value);
 
     void renderingVideoFinished(const QFileInfo& video_file);
 

--- a/libs/mva_gui/qml/MainWindow.qml
+++ b/libs/mva_gui/qml/MainWindow.qml
@@ -48,6 +48,7 @@ ApplicationWindow {
     property bool objectDragActive: false
 
     signal renderingVideoFinished
+    signal userChangedProperty(string item_name, string property_name, var value)
 
     Shortcut {
         sequences: [StandardKey.Delete]
@@ -855,6 +856,12 @@ ApplicationWindow {
             }
         }
     }
+
+    onUserChangedProperty: (item_name, property_name, value) => {
+                               main_window.propertyChangedByUser(item_name,
+                                                                 property_name,
+                                                                 value)
+                           }
 
     Connections {
         target: main_window

--- a/libs/mva_gui/qml/items/MVAMouseArea.qml
+++ b/libs/mva_gui/qml/items/MVAMouseArea.qml
@@ -43,6 +43,8 @@ MouseArea {
                    basicItem.Drag.active = true
                    drag.target = basicItem
 
+                   console.log("Press")
+
                    const component = Qt.createComponent(
                        "MVASurroundingRectangle.qml")
                    if (component.status === Component.Ready) {
@@ -57,6 +59,12 @@ MouseArea {
         basicItem.Drag.active = false
         drag.target = null
         highlightRect.destroy()
+
+        root.userChangedProperty(basicItem.abstract_item.name, "x", basicItem.x)
+        root.userChangedProperty(basicItem.abstract_item.name, "y", basicItem.y)
+
+        console.log("Item", basicItem.abstract_item.name, "moved to (",
+                    basicItem.x, ",", basicItem.y, ")")
     }
 
     Menu {

--- a/libs/mva_gui/qml/items/MVAMouseArea.qml
+++ b/libs/mva_gui/qml/items/MVAMouseArea.qml
@@ -43,8 +43,6 @@ MouseArea {
                    basicItem.Drag.active = true
                    drag.target = basicItem
 
-                   console.log("Press")
-
                    const component = Qt.createComponent(
                        "MVASurroundingRectangle.qml")
                    if (component.status === Component.Ready) {

--- a/libs/mva_gui/qml/models/MVAItemDelegate.qml
+++ b/libs/mva_gui/qml/models/MVAItemDelegate.qml
@@ -32,7 +32,6 @@ Item {
     MouseArea {
 
         function createShadow(file) {
-            console.log("Create shadow")
             var point = mapToItem(null, mouseX, mouseY)
 
             const component = Qt.createComponent(file)

--- a/libs/mva_gui/qml/windows/TextDialog.qml
+++ b/libs/mva_gui/qml/windows/TextDialog.qml
@@ -18,6 +18,8 @@ Dialog {
 
     onAccepted: {
         textItem.latexSource = latexTextArea.text
+        root.userChangedProperty(textItem.name, "latexSource",
+                                 latexTextArea.text)
         createText.close()
     }
     onRejected: createText.close()

--- a/libs/mva_gui/src/windows/mainwindowhandler.cpp
+++ b/libs/mva_gui/src/windows/mainwindowhandler.cpp
@@ -65,6 +65,12 @@ void MainWindowHandler::itemClickedByUser(const QString& item_name) { emit itemC
 
 void MainWindowHandler::setTimeByUser(const QVariant& time) { emit timeChanged(time.toDouble()); }
 
+void MainWindowHandler::propertyChangedByUser(
+    const QString& item_name, const QByteArray& property, const QVariant& value)
+{
+    emit propertyChanged(item_name, property, value);
+}
+
 void MainWindowHandler::updateProjectSettings(const QVariantList& new_project_settings)
 {
     if (new_project_settings.size() != 4) {

--- a/libs/mva_workflow/include/workflow/item_observer.h
+++ b/libs/mva_workflow/include/workflow/item_observer.h
@@ -53,7 +53,7 @@ class ItemObserver : public QObject {
     QList<QSharedPointer<AbstractAnimation>> m_animations;
 
     QVariantMap m_item_start_property_values;
-    QVariantMap m_quick_item_start_property_values;
+    QVariantMap m_basic_item_start_property_values;
 };
 
 inline BasicItem* ItemObserver::item() const { return m_item; }

--- a/libs/mva_workflow/include/workflow/itemhandler.h
+++ b/libs/mva_workflow/include/workflow/itemhandler.h
@@ -69,6 +69,7 @@ class ItemHandler : public QObject {
     void scaleItemsHeight(const qreal ratio);
 
     void setTime(const qreal time);
+    void changeProperty(const QString& item_name, const QByteArray& property, const QVariant& value);
 
   private slots:
     void propertyDataChanged(
@@ -92,6 +93,9 @@ class ItemHandler : public QObject {
     void repopulateAnimationModel(const ItemModelItem* const item);
 
     void setDeleteEachQuickItem(QModelIndex parent = QModelIndex());
+
+    ItemModelItem* getItemModelItemByName(const QString& item_name);
+    QSharedPointer<ItemObserver> getItemObserverByName(const QString& item_name);
 
     QStandardItemModel m_item_model;
     QStandardItemModel m_animation_model;

--- a/libs/mva_workflow/src/item_observer.cpp
+++ b/libs/mva_workflow/src/item_observer.cpp
@@ -29,7 +29,7 @@ ItemObserver::ItemObserver(BasicItem* const item, QObject* parent)
     }
 
     for (const auto& property : quick_item_properties) {
-        m_quick_item_start_property_values.insert(property.first, property.second);
+        m_basic_item_start_property_values.insert(property.first, property.second);
     }
 }
 
@@ -47,9 +47,9 @@ void ItemObserver::applyStartProperties()
         abstractitem()->setProperty(property.toUtf8(), m_item_start_property_values.value(property));
     }
 
-    const auto quick_item_properties = m_quick_item_start_property_values.keys();
-    for (const auto& property : quick_item_properties) {
-        m_item->setProperty(property.toUtf8(), m_quick_item_start_property_values.value(property));
+    const auto basic_item_properties = m_basic_item_start_property_values.keys();
+    for (const auto& property : basic_item_properties) {
+        m_item->setProperty(property.toUtf8(), m_basic_item_start_property_values.value(property));
     }
 }
 
@@ -99,7 +99,7 @@ void ItemObserver::updateItemProperty(const QString& property, const QVariant& v
         return;
     }
     m_item->setProperty(property.toUtf8(), value);
-    m_quick_item_start_property_values.insert(property.toUtf8(), value);
+    m_basic_item_start_property_values.insert(property.toUtf8(), value);
     m_item->update();
 }
 


### PR DESCRIPTION
Fixes #97 

### Proposed changes

* When the user updates a property out of the property editor by moving items or changing latexSource, this is now correctly saved in the ItemObserver
* Add test with moved item

### Motivation behind changes

Bug solving

### Test plan

Integration test added

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [x] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [x] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with MathVizAnimator

* [x] The PR is proposed to proper branch

* [x] There is reference to original bug report and related work

* [x] There is accuracy test, performance test and test data in the repository,
if applicable
