### PR TITLE
Add current project version to save file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
 
-set(PROJECT_VERSION 0.0.1)
-project(mathvizanimator VERSION ${PROJECT_VERSION} LANGUAGES CXX C)
+project(mathvizanimator VERSION 0.0.1 LANGUAGES CXX C)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 message("Run Code Coverage: ${RUN_CODE_COVERAGE}")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -27,6 +27,12 @@ target_include_directories(mva-applib
         src/
 )
 
+target_compile_definitions(mva-applib
+    PUBLIC
+        MVA_PROJECT_VERSION="${PROJECT_VERSION}"
+)
+
+
 add_library(mva::applib ALIAS mva-applib)
 
 qt_add_executable(mva-app

--- a/app/src/mainlogic.cpp
+++ b/app/src/mainlogic.cpp
@@ -122,6 +122,8 @@ void MainLogic::saveProject(const QFileInfo& save_file_info)
         count++;
     }
 
+    save_json.insert("mva-version", MVA_PROJECT_VERSION);
+
     m_savefilehandler.setSaveDir(save_file_info.absoluteDir());
     m_savefilehandler.saveJSON(save_file_info.fileName(), save_json);
 }

--- a/app/tests/integration_tests/tst_menu_file.cpp
+++ b/app/tests/integration_tests/tst_menu_file.cpp
@@ -140,6 +140,12 @@ void MenuFileIntegrationTest::saveAsProject()
     QMetaObject::invokeMethod(save_file_dialog, "simulateAccepted", Qt::DirectConnection);
 
     QVERIFY(QFile::exists(test_save_file_absolute_path));
+
+    SaveFileHandler save_file_handler;
+    const auto load_json_object = save_file_handler.loadJSON(QFileInfo(test_save_file_absolute_path)).object();
+    QVERIFY(load_json_object.contains("item_0"));
+    QVERIFY(load_json_object.contains("mva-version"));
+    QCOMPARE(load_json_object.value("mva-version").toString(), "0.0.1");
 }
 
 void MenuFileIntegrationTest::quitApp()


### PR DESCRIPTION
Fixes #104 

### Proposed changes

* Add current project version to save file

### Motivation behind changes

Later this can be important, then an older save file should be loaded in the app.

### Test plan

Adapted CI test for this task.

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [ ] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [ ] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with MathVizAnimator

* [ ] The PR is proposed to proper branch

* [ ] There is reference to original bug report and related work

* [ ] There is accuracy test, performance test and test data in the repository,
if applicable
