### PR TITLE
Add default suffix to FileDialogs

### DIFF
--- a/libs/mva_gui/qml/MainWindow.qml
+++ b/libs/mva_gui/qml/MainWindow.qml
@@ -85,6 +85,7 @@ ApplicationWindow {
         currentFolder: StandardPaths.standardLocations(
                            StandardPaths.HomeLocation)[0]
         fileMode: FileDialog.SaveFile
+        defaultSuffix: ".json"
         nameFilters: ["JSON (*.json)"]
 
         onAccepted: main_window.saveProject(selectedFile)
@@ -103,6 +104,7 @@ ApplicationWindow {
         currentFolder: StandardPaths.standardLocations(
                            StandardPaths.HomeLocation)[0]
         fileMode: FileDialog.SaveFile
+        defaultSuffix: ".mp4"
         nameFilters: ["MP4 (*.mp4)"]
 
         onAccepted: main_window.render(selectedFile)
@@ -121,6 +123,7 @@ ApplicationWindow {
         currentFolder: StandardPaths.standardLocations(
                            StandardPaths.HomeLocation)[0]
         fileMode: FileDialog.SaveFile
+        defaultSuffix: ".png"
         nameFilters: ["PNG (*.png)"]
 
         onAccepted: main_window.snapshot(selectedFile)


### PR DESCRIPTION
Fixes #111

### Proposed changes

* Add default suffix to FileDialogs

### Motivation behind changes

When no extension is added by the user, a default one is used. This makes the application safer to use.

### Test plan

Can't really be tested, since the FileDialogs UI can't be truly used for testing. 

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [x] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [x] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with MathVizAnimator

* [x] The PR is proposed to proper branch

* [x] There is reference to original bug report and related work

* [x] There is accuracy test, performance test and test data in the repository,
if applicable
