### PR TITLE
Add project settings to save file and fix bug

### DIFF
--- a/app/src/mainlogic.cpp
+++ b/app/src/mainlogic.cpp
@@ -123,6 +123,7 @@ void MainLogic::saveProject(const QFileInfo& save_file_info)
     }
 
     save_json.insert("mva-version", MVA_PROJECT_VERSION);
+    save_json.insert("project-settings", projectSettingsJson());
 
     m_savefilehandler.setSaveDir(save_file_info.absoluteDir());
     m_savefilehandler.saveJSON(save_file_info.fileName(), save_json);
@@ -133,6 +134,9 @@ void MainLogic::loadProject(const QFileInfo& load_file_info)
     QJsonDocument loadDoc = m_savefilehandler.loadJSON(load_file_info);
 
     QJsonObject json = loadDoc.object();
+
+    setProjectSettings(json["project-settings"].toObject());
+
     for (const QString& itemKey : json.keys()) {
         auto item_json = json[itemKey].toObject();
 
@@ -217,3 +221,25 @@ void MainLogic::uiTimeChanged(const qreal time)
 }
 
 void MainLogic::renderingVideoFinished() { uiTimeChanged(m_current_time); }
+
+QJsonObject MainLogic::projectSettingsJson() const
+{
+    QJsonObject json;
+
+    const auto current_project_settings = m_renderer.projectSettings();
+
+    json.insert("width", current_project_settings.width);
+    json.insert("height", current_project_settings.height);
+    json.insert("fps", current_project_settings.fps);
+    json.insert("video_length", current_project_settings.video_length);
+
+    return json;
+}
+
+void MainLogic::setProjectSettings(const QJsonObject& json)
+{
+    m_mainwindowhandler.setPixelWidth(json["width"].toInt());
+    m_mainwindowhandler.setPixelHeight(json["height"].toInt());
+    m_mainwindowhandler.setFPS(json["fps"].toInt());
+    m_mainwindowhandler.setVideoLength(json["video_length"].toInt());
+}

--- a/app/src/mainlogic.h
+++ b/app/src/mainlogic.h
@@ -52,6 +52,9 @@ class MainLogic : public QObject {
     void renderingVideoFinished();
 
   private:
+    QJsonObject projectSettingsJson() const;
+    void setProjectSettings(const QJsonObject& json);
+
     QQmlApplicationEngine* m_qml_engine;
     QObject* m_qml_creation_area;
 

--- a/app/tests/integration_tests/test_helper_functions.cpp
+++ b/app/tests/integration_tests/test_helper_functions.cpp
@@ -19,12 +19,14 @@
 
 #include <QAbstractEventDispatcher>
 #include <QQmlApplicationEngine>
+#include <QQmlContext>
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QStandardItemModel>
 #include <QTest> // should be removed, see comment in constructor
 
 #include "itemhandler.h"
+#include "mainwindowhandler.h"
 
 TestHelperFunctions::TestHelperFunctions(const QSharedPointer<QQmlApplicationEngine> engine)
     : m_engine(engine)
@@ -47,6 +49,7 @@ TestHelperFunctions::TestHelperFunctions(const QSharedPointer<QQmlApplicationEng
     m_animations_table_view = root_objects.first()->findChild<QObject*>("MVAAnimationTable");
     m_creation_area = root_objects.first()->findChild<QQuickItem*>("MVACreationArea");
     m_time_slider = root_objects.first()->findChild<QQuickItem*>("MVATimeSlider");
+    m_main_window_handler = m_engine->rootContext()->contextProperty("main_window").value<MainWindowHandler*>();
 
     auto items_model = m_project_items_table_view->property("model");
     m_project_items_model = qvariant_cast<QStandardItemModel*>(items_model);

--- a/app/tests/integration_tests/test_helper_functions.h
+++ b/app/tests/integration_tests/test_helper_functions.h
@@ -27,6 +27,7 @@ class QQuickItem;
 class QQuickWindow;
 class QStandardItemModel;
 class QQmlApplicationEngine;
+class MainWindowHandler;
 
 class TestHelperFunctions {
   public:
@@ -44,6 +45,7 @@ class TestHelperFunctions {
     QObject* draggableItemListView() const { return m_draggable_item_list_view; }
     QObject* projectItemsTableView() const { return m_project_items_table_view; }
     QQuickItem* creationArea() const { return m_creation_area; }
+    MainWindowHandler* mainWindowHandler() const { return m_main_window_handler; }
 
     QSharedPointer<ItemObserver> getItemObserver(const qint32 item_number) const;
     QQuickItem* getQuickItem(const qint32 item_number) const;
@@ -85,6 +87,8 @@ class TestHelperFunctions {
     QStandardItemModel* m_animations_model = Q_NULLPTR;
     QQuickItem* m_creation_area = Q_NULLPTR;
     QQuickItem* m_time_slider = Q_NULLPTR;
+
+    MainWindowHandler* m_main_window_handler = Q_NULLPTR;
 };
 
 #endif // APP_TESTS_INTEGRATION_TESTS_TEST_HELPER_FUNCTIONS_H_

--- a/app/tests/integration_tests/tst_menu_file.cpp
+++ b/app/tests/integration_tests/tst_menu_file.cpp
@@ -89,6 +89,10 @@ void MenuFileIntegrationTest::loadProject()
     QVERIFY(test_save_file.exists());
 
     const QString test_load_file_absolute_path = TestHelperFunctions::absoluteFilePath("test_load_file.json");
+    if (QFile::exists(test_load_file_absolute_path)) {
+        QFile::remove(test_load_file_absolute_path);
+    }
+
     test_save_file.copy(test_load_file_absolute_path);
     QVERIFY(QFile::exists(test_load_file_absolute_path));
 
@@ -101,11 +105,17 @@ void MenuFileIntegrationTest::loadProject()
     load_file_dialog->setProperty("selectedFile", QVariant(QUrl::fromLocalFile(test_load_file_absolute_path)));
     QMetaObject::invokeMethod(load_file_dialog, "simulateAccepted", Qt::QueuedConnection);
 
+    const auto main_window_handler = m_helper_functions->mainWindowHandler();
+
     QVERIFY(QTest::qWaitFor([&]() { return !load_file_dialog->property("visible").toBool(); }));
     QVERIFY(m_helper_functions->compareNumItems(3));
     QVERIFY(m_helper_functions->compareNumAnimations("rect", 2));
     QVERIFY(m_helper_functions->compareNumAnimations("circle", 1));
     QVERIFY(m_helper_functions->compareNumAnimations("text", 0));
+    QCOMPARE(main_window_handler->property("pixel_width").toInt(), 1200);
+    QCOMPARE(main_window_handler->property("pixel_height").toInt(), 800);
+    QCOMPARE(main_window_handler->property("fps").toInt(), 32);
+    QCOMPARE(main_window_handler->property("video_length").toInt(), 8);
 
     // Check if item is clickable, see Issue #37
     auto rect_item = m_helper_functions->getQuickItem(0);
@@ -145,7 +155,15 @@ void MenuFileIntegrationTest::saveAsProject()
     const auto load_json_object = save_file_handler.loadJSON(QFileInfo(test_save_file_absolute_path)).object();
     QVERIFY(load_json_object.contains("item_0"));
     QVERIFY(load_json_object.contains("mva-version"));
+    QVERIFY(load_json_object.contains("project-settings"));
+    QVERIFY(load_json_object.value("project-settings").isObject());
+
+    const auto project_settings_object = load_json_object.value("project-settings").toObject();
     QCOMPARE(load_json_object.value("mva-version").toString(), "0.0.1");
+    QCOMPARE(project_settings_object.value("width").toInt(), 1024);
+    QCOMPARE(project_settings_object.value("height").toInt(), 768);
+    QCOMPARE(project_settings_object.value("fps").toInt(), 24);
+    QCOMPARE(project_settings_object.value("video_length").toInt(), 5);
 }
 
 void MenuFileIntegrationTest::quitApp()

--- a/app/tests/integration_tests_data/test_save_file.json
+++ b/app/tests/integration_tests_data/test_save_file.json
@@ -45,5 +45,11 @@
         "abstract_item.scaleText": "5",
         "x": "200",
         "y": "499"
+    },
+    "project-settings": {
+        "fps": 32,
+        "height": 800,
+        "video_length": 8,
+        "width": 1200
     }
 }

--- a/libs/mva_gui/src/items/abstractitem.cpp
+++ b/libs/mva_gui/src/items/abstractitem.cpp
@@ -48,7 +48,7 @@ QJsonObject AbstractItem::toJson() const
     properties.append(QPair<QString, QVariant> { "file", m_qml_file });
 
     for (auto& property : properties) {
-        json["item." + property.first] = property.second.toString();
+        json["abstract_item." + property.first] = property.second.toString();
     }
 
     for (auto& property : parent_properties) {

--- a/libs/mva_gui/tests/items/circleitem/tst_circleitem.cpp
+++ b/libs/mva_gui/tests/items/circleitem/tst_circleitem.cpp
@@ -77,15 +77,15 @@ void TestCircleItem::toJsonTest()
     expected_json["y"] = QString::number(m_circle_y);
     expected_json["width"] = QString::number(m_circle_width);
     expected_json["height"] = QString::number(m_circle_height);
-    expected_json["item.filledColor"] = m_circle_filled_color;
-    expected_json["item.filledOpacity"] = QString::number(m_circle_filled_opacity);
-    expected_json["item.borderColor"] = m_circle_border_color;
-    expected_json["item.borderOpacity"] = QString::number(m_circle_border_opacity);
-    expected_json["item.borderWidth"] = QString::number(m_circle_border_width);
-    expected_json["item.name"] = m_circle_name;
-    expected_json["item.opacity"] = QString::number(m_circle_opacity);
-    expected_json["item.rotation"] = QString::number(m_circle_rotation);
-    expected_json["item.file"] = "qrc:/qt/qml/cwa/mva/gui/qml/items/MVACircle.qml";
+    expected_json["abstract_item.filledColor"] = m_circle_filled_color;
+    expected_json["abstract_item.filledOpacity"] = QString::number(m_circle_filled_opacity);
+    expected_json["abstract_item.borderColor"] = m_circle_border_color;
+    expected_json["abstract_item.borderOpacity"] = QString::number(m_circle_border_opacity);
+    expected_json["abstract_item.borderWidth"] = QString::number(m_circle_border_width);
+    expected_json["abstract_item.name"] = m_circle_name;
+    expected_json["abstract_item.opacity"] = QString::number(m_circle_opacity);
+    expected_json["abstract_item.rotation"] = QString::number(m_circle_rotation);
+    expected_json["abstract_item.file"] = "qrc:/qt/qml/cwa/mva/gui/qml/items/MVACircle.qml";
 
     const auto circle_json = m_circle_item.toJson();
 

--- a/libs/mva_gui/tests/items/rectangleitem/tst_rectangleitem.cpp
+++ b/libs/mva_gui/tests/items/rectangleitem/tst_rectangleitem.cpp
@@ -67,15 +67,15 @@ void TestRectangleItem::toJsonTest()
     expected_json["y"] = QString::number(m_rect_y);
     expected_json["width"] = QString::number(m_rect_width);
     expected_json["height"] = QString::number(m_rect_height);
-    expected_json["item.filledColor"] = "#00000000";
-    expected_json["item.filledOpacity"] = "1";
-    expected_json["item.borderColor"] = m_rect_color;
-    expected_json["item.borderOpacity"] = "1";
-    expected_json["item.borderWidth"] = "4";
-    expected_json["item.name"] = m_rect_name;
-    expected_json["item.rotation"] = QString::number(m_rect_rotation);
-    expected_json["item.opacity"] = QString::number(m_rect_opacity);
-    expected_json["item.file"] = "qrc:/qt/qml/cwa/mva/gui/qml/items/MVARectangle.qml";
+    expected_json["abstract_item.filledColor"] = "#00000000";
+    expected_json["abstract_item.filledOpacity"] = "1";
+    expected_json["abstract_item.borderColor"] = m_rect_color;
+    expected_json["abstract_item.borderOpacity"] = "1";
+    expected_json["abstract_item.borderWidth"] = "4";
+    expected_json["abstract_item.name"] = m_rect_name;
+    expected_json["abstract_item.rotation"] = QString::number(m_rect_rotation);
+    expected_json["abstract_item.opacity"] = QString::number(m_rect_opacity);
+    expected_json["abstract_item.file"] = "qrc:/qt/qml/cwa/mva/gui/qml/items/MVARectangle.qml";
 
     const auto rect_json = m_rect_item.toJson();
 

--- a/libs/mva_gui/tests/items/textitem/tst_textitem.cpp
+++ b/libs/mva_gui/tests/items/textitem/tst_textitem.cpp
@@ -59,12 +59,12 @@ void TestTextItem::toJsonTest()
     QJsonObject expected_json;
     expected_json["x"] = QString::number(m_text_x);
     expected_json["y"] = QString::number(m_text_y);
-    expected_json["item.name"] = m_text_name;
-    expected_json["item.rotation"] = QString::number(m_text_rotation);
-    expected_json["item.opacity"] = QString::number(m_text_opacity);
-    expected_json["item.scaleText"] = QString::number(m_text_scale);
-    expected_json["item.file"] = "qrc:/qt/qml/cwa/mva/gui/qml/items/MVAText.qml";
-    expected_json["item.latexSource"] = "";
+    expected_json["abstract_item.name"] = m_text_name;
+    expected_json["abstract_item.rotation"] = QString::number(m_text_rotation);
+    expected_json["abstract_item.opacity"] = QString::number(m_text_opacity);
+    expected_json["abstract_item.scaleText"] = QString::number(m_text_scale);
+    expected_json["abstract_item.file"] = "qrc:/qt/qml/cwa/mva/gui/qml/items/MVAText.qml";
+    expected_json["abstract_item.latexSource"] = "";
 
     const auto text_json = m_text_item.toJson();
 


### PR DESCRIPTION
Fixes #112 
### Proposed changes

* Project settings are now stored in the savefile
* Project settings are changed to values from savefile when loading it.

### Motivation behind changes

When loading a savefile you should not have to change the project settings every time.

### Test plan

Adapted integration tests for project saving/loading.

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [x] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [x] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with MathVizAnimator

* [x] The PR is proposed to proper branch

* [x] There is reference to original bug report and related work

* [x] There is accuracy test, performance test and test data in the repository,
if applicable

