### PR TITLE
Scale border width and replace project size property

### DIFF
--- a/app/src/mainlogic.h
+++ b/app/src/mainlogic.h
@@ -45,8 +45,7 @@ class MainLogic : public QObject {
     void saveProject(const QFileInfo& save_file_info);
     void loadProject(const QFileInfo& load_file_info);
 
-    void projectWidthChanged(const qint32 new_project_width);
-    void projectHeightChanged(const qint32 new_project_height);
+    void projectSizeChanged();
 
     void uiTimeChanged(const qreal time);
     void renderingVideoFinished();

--- a/app/tests/integration_tests/tst_menu_file.cpp
+++ b/app/tests/integration_tests/tst_menu_file.cpp
@@ -112,8 +112,7 @@ void MenuFileIntegrationTest::loadProject()
     QVERIFY(m_helper_functions->compareNumAnimations("rect", 2));
     QVERIFY(m_helper_functions->compareNumAnimations("circle", 1));
     QVERIFY(m_helper_functions->compareNumAnimations("text", 0));
-    QCOMPARE(main_window_handler->property("pixel_width").toInt(), 1200);
-    QCOMPARE(main_window_handler->property("pixel_height").toInt(), 800);
+    QCOMPARE(main_window_handler->property("project_size").toSize(), QSize(1200, 800));
     QCOMPARE(main_window_handler->property("fps").toInt(), 32);
     QCOMPARE(main_window_handler->property("video_length").toInt(), 8);
 

--- a/app/tests/integration_tests/tst_menu_project.cpp
+++ b/app/tests/integration_tests/tst_menu_project.cpp
@@ -89,8 +89,8 @@ void MenuProjectIntegrationTest::renderProjectAtNonZeroProjectTime()
 
     const auto main_window_handler = m_helper_functions->mainWindowHandler();
     const auto size = main_window_handler->property("project_size").toSize();
-    QImage full_white_image(size, QImage::Format::Format_RGB32);
-    full_white_image.fill(QColor("black"));
+    QImage full_black_image(size, QImage::Format::Format_RGB32);
+    full_black_image.fill(QColor("black"));
 
     QCOMPARE(rendered_image, full_black_image);
 }

--- a/app/tests/integration_tests/tst_menu_project.cpp
+++ b/app/tests/integration_tests/tst_menu_project.cpp
@@ -88,9 +88,8 @@ void MenuProjectIntegrationTest::renderProjectAtNonZeroProjectTime()
     const auto rendered_image = m_helper_functions->extractImage(render_file);
 
     const auto main_window_handler = m_helper_functions->mainWindowHandler();
-    const auto width = main_window_handler->property("pixel_width").toInt();
-    const auto height = main_window_handler->property("pixel_height").toInt();
-    QImage full_white_image(QSize(width, height), QImage::Format::Format_RGB32);
+    const auto size = main_window_handler->property("project_size").toSize();
+    QImage full_white_image(size, QImage::Format::Format_RGB32);
     full_white_image.fill(QColor("white"));
 
     QCOMPARE(rendered_image, full_white_image);

--- a/libs/mva_gui/include/items/textitem.h
+++ b/libs/mva_gui/include/items/textitem.h
@@ -31,26 +31,26 @@ class TextItem : public AbstractItem {
 
     // TODO(codingwithmagga): Relocate to a SvgHandler class or LatexHandler or
     // similar
-    Q_PROPERTY(QString latexSource READ getLatexSource WRITE setLatexSource NOTIFY latexSourceChanged)
+    Q_PROPERTY(QString latexSource READ latexSource WRITE setLatexSource NOTIFY latexSourceChanged)
 
-    Q_PROPERTY(QString svgFile READ getSvgFile WRITE setSvgFile NOTIFY svgFileChanged)
-    Q_PROPERTY(qreal scaleText READ getScaleText WRITE setScaleText NOTIFY scaleTextChanged)
+    Q_PROPERTY(QString svgFile READ svgFile WRITE setSvgFile NOTIFY svgFileChanged)
+    Q_PROPERTY(qreal scaleText READ scaleText WRITE setScaleText NOTIFY scaleTextChanged)
 
   public:
     explicit TextItem(BasicItem* parent = nullptr);
 
-    QString getSvgFile() const { return m_svg_file.absoluteFilePath(); }
+    QString svgFile() const { return m_svg_file.absoluteFilePath(); }
     void setSvgFile(const QFileInfo& newSvgFile);
     void setSvgFile(const QString& newSvgFile);
 
     void paint(QPainter* painter) override;
 
-    QString getLatexSource() const;
+    QString latexSource() const;
     // TODO(codingwithmagga): Relocate to a SvgHandler class or LatexHandler or
     // similar
     void setLatexSource(const QString& newLatexSource);
 
-    qreal getScaleText() const;
+    qreal scaleText() const;
     void setScaleText(qreal newScaleText);
 
     EditableProperties editableProperties() const override;

--- a/libs/mva_gui/include/windows/mainwindowhandler.h
+++ b/libs/mva_gui/include/windows/mainwindowhandler.h
@@ -34,7 +34,7 @@ class MainWindowHandler : public QObject {
 
   public:
     explicit MainWindowHandler(QObject* parent = Q_NULLPTR);
-  
+
     qint32 fps() const;
     void setFPS(const qint32 new_fps);
 
@@ -101,7 +101,6 @@ class MainWindowHandler : public QObject {
 
   private:
     QObject* m_qml_creation_area;
-
 
     QSize m_project_size = QSize(1024, 768);
     qint32 m_fps = 24;

--- a/libs/mva_gui/include/windows/mainwindowhandler.h
+++ b/libs/mva_gui/include/windows/mainwindowhandler.h
@@ -27,18 +27,18 @@
 class MainWindowHandler : public QObject {
     Q_OBJECT
 
-    Q_PROPERTY(qint32 pixel_width READ pixelWidth WRITE setPixelWidth NOTIFY pixelWidthChanged)
-    Q_PROPERTY(qint32 pixel_height READ pixelHeight WRITE setPixelHeight NOTIFY pixelHeightChanged)
+    Q_PROPERTY(QSize project_size READ projectSize WRITE setProjectSize NOTIFY projectSizeChanged)
     Q_PROPERTY(qint32 fps READ fps WRITE setFPS NOTIFY fpsChanged)
     Q_PROPERTY(qint32 video_length READ videoLength WRITE setVideoLength NOTIFY videoLengthChanged)
 
   public:
     explicit MainWindowHandler(QObject* parent = Q_NULLPTR);
 
-    qint32 pixelWidth() const;
-    qint32 pixelHeight() const;
     qint32 fps() const;
     qint32 videoLength() const;
+
+    QSize projectSize() const;
+    void setProjectSize(const QSize& new_project_size);
 
   public slots:
 
@@ -63,8 +63,6 @@ class MainWindowHandler : public QObject {
     void updateProjectSettings(const QVariantList& new_project_settings);
     void updateProjectSettings(const QList<qint32>& new_project_settings);
 
-    void setPixelWidth(const qint32 new_pixel_width);
-    void setPixelHeight(const qint32 new_pixel_height);
     void setFPS(const qint32 new_fps);
     void setVideoLength(const qint32 new_video_length);
 
@@ -72,10 +70,9 @@ class MainWindowHandler : public QObject {
         const QString& item_name, const QString& animation_type, const qreal start_time, const qreal duration);
 
   signals:
-    void pixelWidthChanged(const qint32 new_pixel_width);
-    void pixelHeightChanged(const qint32 new_pixel_height);
     void fpsChanged(const qint32 new_fps);
     void videoLengthChanged(const qint32 new_video_length);
+    void projectSizeChanged();
 
     void snapshotRequested(const QFileInfo& snapshot_file_info);
     void renderingRequested(const QFileInfo& video_file_info);
@@ -100,10 +97,9 @@ class MainWindowHandler : public QObject {
   private:
     QObject* m_qml_creation_area;
 
-    qint32 m_pixel_width;
-    qint32 m_pixel_height;
     qint32 m_fps;
     qint32 m_video_length;
+    QSize m_project_size;
 };
 
 #endif // LIBS_MVA_GUI_INCLUDE_WINDOWS_MAINWINDOWHANDLER_H_

--- a/libs/mva_gui/qml/MainWindow.qml
+++ b/libs/mva_gui/qml/MainWindow.qml
@@ -218,7 +218,7 @@ ApplicationWindow {
                     id: widthInputField
                     objectName: "MVAWidthInputField"
 
-                    text: main_window.pixel_width
+                    text: main_window.project_size.width
 
                     horizontalAlignment: TextInput.AlignRight
 
@@ -239,7 +239,7 @@ ApplicationWindow {
                     id: heightInputField
                     objectName: "MVAHeightInputField"
 
-                    text: main_window.pixel_height
+                    text: main_window.project_size.height
 
                     horizontalAlignment: TextInput.AlignRight
 
@@ -478,7 +478,8 @@ ApplicationWindow {
                 Item {
                     id: dropAreaContainer
 
-                    property real aimedRatio: main_window.pixel_height / main_window.pixel_width
+                    property real aimedRatio: main_window.project_size.height
+                                              / main_window.project_size.width
 
                     property bool parentIsLarge: parentRatio > aimedRatio
                     property real parentRatio: parent.height / parent.width
@@ -493,7 +494,7 @@ ApplicationWindow {
                         property var newItem: null
                         property var abstractComponent: null
 
-                        property double baseWidth: main_window.pixel_width
+                        property double baseWidth: main_window.project_size.width
                         property double baseHeight: baseWidth * dropAreaContainer.aimedRatio
                         property double scaleFactor: dropAreaContainer.availableWidth / baseWidth
 

--- a/libs/mva_gui/src/items/textitem.cpp
+++ b/libs/mva_gui/src/items/textitem.cpp
@@ -82,7 +82,7 @@ void TextItem::paint(QPainter* painter)
     painter->restore();
 }
 
-QString TextItem::getLatexSource() const { return m_latex_source; }
+QString TextItem::latexSource() const { return m_latex_source; }
 
 // TODO(codingwithmagga): Refactor this function
 void TextItem::setLatexSource(const QString& newLatexSource)
@@ -150,7 +150,7 @@ void TextItem::setLatexSource(const QString& newLatexSource)
     emit latexSourceChanged(newLatexSource);
 }
 
-qreal TextItem::getScaleText() const { return m_scale_text; }
+qreal TextItem::scaleText() const { return m_scale_text; }
 
 void TextItem::setScaleText(qreal newScaleText)
 {

--- a/libs/mva_gui/src/windows/mainwindowhandler.cpp
+++ b/libs/mva_gui/src/windows/mainwindowhandler.cpp
@@ -166,6 +166,7 @@ void MainWindowHandler::setProjectSize(const QSize& new_project_size)
 
     m_project_size = new_project_size;
     emit projectSizeChanged();
+}
 
 QColor MainWindowHandler::backgroundColor() const { return m_background_color; }
 

--- a/libs/mva_gui/src/windows/mainwindowhandler.cpp
+++ b/libs/mva_gui/src/windows/mainwindowhandler.cpp
@@ -90,8 +90,7 @@ void MainWindowHandler::updateProjectSettings(const QList<qint32>& new_project_s
         return;
     }
 
-    setPixelWidth(new_project_settings[0]);
-    setPixelHeight(new_project_settings[1]);
+    setProjectSize(QSize(new_project_settings[0], new_project_settings[1]));
     setFPS(new_project_settings[2]);
     setVideoLength(new_project_settings[3]);
 }
@@ -102,33 +101,9 @@ void MainWindowHandler::newProject()
     emit newProjectRequested();
 }
 
-qint32 MainWindowHandler::pixelWidth() const { return m_pixel_width; }
-
-qint32 MainWindowHandler::pixelHeight() const { return m_pixel_height; }
-
 qint32 MainWindowHandler::fps() const { return m_fps; }
 
 qint32 MainWindowHandler::videoLength() const { return m_video_length; }
-
-void MainWindowHandler::setPixelWidth(const qint32 new_pixel_width)
-{
-    if (m_pixel_width == new_pixel_width) {
-        return;
-    }
-
-    m_pixel_width = new_pixel_width;
-    emit pixelWidthChanged(new_pixel_width);
-}
-
-void MainWindowHandler::setPixelHeight(const qint32 new_pixel_height)
-{
-    if (m_pixel_height == new_pixel_height) {
-        return;
-    }
-
-    m_pixel_height = new_pixel_height;
-    emit pixelHeightChanged(new_pixel_height);
-}
 
 void MainWindowHandler::setFPS(const qint32 new_fps)
 {
@@ -181,4 +156,16 @@ void MainWindowHandler::addItem(QQuickItem* item)
     // clang-format on
 
     emit itemAdded(basic_item);
+}
+
+QSize MainWindowHandler::projectSize() const { return m_project_size; }
+
+void MainWindowHandler::setProjectSize(const QSize& new_project_size)
+{
+    if (m_project_size == new_project_size) {
+        return;
+    }
+
+    m_project_size = new_project_size;
+    emit projectSizeChanged();
 }

--- a/libs/mva_gui/tests/items/textitem/tst_textitem.cpp
+++ b/libs/mva_gui/tests/items/textitem/tst_textitem.cpp
@@ -85,8 +85,8 @@ void TestTextItem::latexRenderTest()
     m_text_item.setLatexSource(test_latex);
 
     QVERIFY(svg_file.exists());
-    QCOMPARE(m_text_item.getLatexSource(), test_latex);
-    QCOMPARE(m_text_item.getSvgFile(), appPath.absoluteFilePath(svg_file.fileName()));
+    QCOMPARE(m_text_item.latexSource(), test_latex);
+    QCOMPARE(m_text_item.svgFile(), appPath.absoluteFilePath(svg_file.fileName()));
     QVERIFY(!QFile::exists(appPath.absoluteFilePath(hash + ".aux")));
     QVERIFY(!QFile::exists(appPath.absoluteFilePath(hash + ".dvi")));
     QVERIFY(!QFile::exists(appPath.absoluteFilePath(hash + ".log")));

--- a/libs/mva_gui/tests/windows/test_mainwindowhandler.cpp
+++ b/libs/mva_gui/tests/windows/test_mainwindowhandler.cpp
@@ -51,8 +51,7 @@ class TestMainWindowHandler : public QObject {
 
     QList<QSharedPointer<QSignalSpy>> createPropertySignalSpies(const MainWindowHandler& main_window_handler);
 
-    const qint32 m_width = 1000;
-    const qint32 m_height = 800;
+    const QSize m_size = QSize(1000, 800);
     const qint32 m_fps = 12;
     const qint32 m_video_length = 8;
 };
@@ -73,7 +72,7 @@ void TestMainWindowHandler::changedPropertyTests()
 void TestMainWindowHandler::unchangedPropertyTests()
 {
     MainWindowHandler main_window_handler;
-    QList<int> project_settings { m_width, m_height, m_fps, m_video_length };
+    QList<int> project_settings { m_size.width(), m_size.height(), m_fps, m_video_length };
     main_window_handler.updateProjectSettings(project_settings);
     const auto spyList = createPropertySignalSpies(main_window_handler);
 
@@ -207,7 +206,7 @@ void TestMainWindowHandler::updateProjectSettingsAsVariant()
 {
     MainWindowHandler main_window_handler;
     const auto spyList = createPropertySignalSpies(main_window_handler);
-    QVariantList project_settings { m_width, m_height, m_fps, m_video_length };
+    QVariantList project_settings { m_size.width(), m_size.height(), m_fps, m_video_length };
 
     main_window_handler.updateProjectSettings(project_settings);
 
@@ -221,7 +220,7 @@ void TestMainWindowHandler::updateProjectSettingsAsInt()
 {
     MainWindowHandler main_window_handler;
     const auto spyList = createPropertySignalSpies(main_window_handler);
-    QList<qint32> project_settings { m_width, m_height, m_fps, m_video_length };
+    QList<qint32> project_settings { m_size.width(), m_size.height(), m_fps, m_video_length };
 
     main_window_handler.updateProjectSettings(project_settings);
 
@@ -235,7 +234,7 @@ void TestMainWindowHandler::updateProjectSettingsAsVariantWrongSize()
 {
     MainWindowHandler main_window_handler;
     const auto spyList = createPropertySignalSpies(main_window_handler);
-    QVariantList project_settings { m_width, m_height, m_fps };
+    QVariantList project_settings { m_size.width(), m_fps };
 
     main_window_handler.updateProjectSettings(project_settings);
 
@@ -248,7 +247,7 @@ void TestMainWindowHandler::updateProjectSettingsAsIntWrongSize()
 {
     MainWindowHandler main_window_handler;
     const auto spyList = createPropertySignalSpies(main_window_handler);
-    QList<qint32> project_settings { m_width, m_fps, m_video_length };
+    QList<qint32> project_settings { m_size.width(), m_fps, m_video_length };
 
     main_window_handler.updateProjectSettings(project_settings);
 
@@ -259,16 +258,14 @@ void TestMainWindowHandler::updateProjectSettingsAsIntWrongSize()
 
 void TestMainWindowHandler::setMainWindowProperties(MainWindowHandler* main_window_handler)
 {
-    main_window_handler->setPixelWidth(m_width);
-    main_window_handler->setPixelHeight(m_height);
+    main_window_handler->setProjectSize(m_size);
     main_window_handler->setFPS(m_fps);
     main_window_handler->setVideoLength(m_video_length);
 }
 
 void TestMainWindowHandler::checkProperties(const MainWindowHandler& main_window_handler)
 {
-    QCOMPARE(main_window_handler.pixelWidth(), m_width);
-    QCOMPARE(main_window_handler.pixelHeight(), m_height);
+    QCOMPARE(main_window_handler.projectSize(), m_size);
     QCOMPARE(main_window_handler.fps(), m_fps);
     QCOMPARE(main_window_handler.videoLength(), m_video_length);
 }
@@ -279,9 +276,7 @@ QList<QSharedPointer<QSignalSpy>> TestMainWindowHandler::createPropertySignalSpi
     QList<QSharedPointer<QSignalSpy>> spy_list;
 
     spy_list.append(
-        QSharedPointer<QSignalSpy>(new QSignalSpy(&main_window_handler, &MainWindowHandler::pixelWidthChanged)));
-    spy_list.append(
-        QSharedPointer<QSignalSpy>(new QSignalSpy(&main_window_handler, &MainWindowHandler::pixelHeightChanged)));
+        QSharedPointer<QSignalSpy>(new QSignalSpy(&main_window_handler, &MainWindowHandler::projectSizeChanged)));
     spy_list.append(QSharedPointer<QSignalSpy>(new QSignalSpy(&main_window_handler, &MainWindowHandler::fpsChanged)));
     spy_list.append(
         QSharedPointer<QSignalSpy>(new QSignalSpy(&main_window_handler, &MainWindowHandler::videoLengthChanged)));

--- a/libs/mva_workflow/include/workflow/itemhandler.h
+++ b/libs/mva_workflow/include/workflow/itemhandler.h
@@ -49,6 +49,8 @@ class ItemHandler : public QObject {
     QList<BasicItem*> basicItems();
     QList<QSharedPointer<ItemObserver>> items();
 
+    void scaleItems(const qreal width_ratio, const qreal height_ratio);
+
   public slots:
     void clear();
 
@@ -61,12 +63,6 @@ class ItemHandler : public QObject {
         const QString& item_name, const QString& animation_type, const qreal start_time, const qreal duration);
     void addAnimations(const QString& item_name, const QList<QSharedPointer<AbstractAnimation>> animations);
     void removeAnimation(const qint32 animation_number);
-
-    void scaleItemsX(const qreal ratio);
-    void scaleItemsY(const qreal ratio);
-
-    void scaleItemsWidth(const qreal ratio);
-    void scaleItemsHeight(const qreal ratio);
 
     void setTime(const qreal time);
     void changeProperty(const QString& item_name, const QByteArray& property, const QVariant& value);

--- a/libs/mva_workflow/include/workflow/renderer.h
+++ b/libs/mva_workflow/include/workflow/renderer.h
@@ -30,8 +30,7 @@ class Renderer : public QObject {
 
   public:
     struct ProjectSettings {
-        qint32 width = 1024;
-        qint32 height = 768;
+        QSize size = QSize(1024, 768);
         qint32 fps = 24;
         qint32 video_length = 5;
     };
@@ -41,8 +40,7 @@ class Renderer : public QObject {
     ProjectSettings projectSettings() const;
     void setProjectSettings(const ProjectSettings& new_project_settings);
 
-    void setWidth(const qint32 new_width);
-    void setHeight(const qint32 new_height);
+    void setProjectSize(const QSize new_project_size);
     void setFPS(const qint32 new_fps);
     void setVideoLength(const qint32 new_video_length);
 

--- a/libs/mva_workflow/src/itemhandler.cpp
+++ b/libs/mva_workflow/src/itemhandler.cpp
@@ -21,7 +21,9 @@
 #include "basic_item.h"
 #include "fade_in.h"
 #include "fade_out.h"
+#include "geometry_item.h"
 #include "logging.h"
+#include "textitem.h"
 
 ItemHandler::ItemHandler(QObject* parent)
     : QObject { parent }
@@ -73,6 +75,29 @@ QList<QSharedPointer<ItemObserver>> ItemHandler::items()
         list.append(dynamic_cast<ItemModelItem*>(item)->itemObserver());
     }
     return list;
+}
+
+void ItemHandler::scaleItems(const qreal width_ratio, const qreal height_ratio)
+{
+    const auto itemList = basicItems();
+    const auto avg_ratio = (width_ratio + height_ratio) / 2.0;
+
+    for (auto& item : itemList) {
+        item->setX(qRound(item->x() * width_ratio));
+        item->setWidth(qRound(item->width() * width_ratio));
+        item->setY(qRound(item->y() * height_ratio));
+        item->setHeight(qRound(item->height() * height_ratio));
+
+        auto abstract_item = item->abstractItem();
+        auto geometry_item = qobject_cast<GeometryItem*>(abstract_item);
+        auto text_item = qobject_cast<TextItem*>(abstract_item);
+        if (geometry_item) {
+            geometry_item->setBorderWidth(qRound(geometry_item->borderWidth() * avg_ratio));
+        }
+        if (text_item) {
+            text_item->setScaleText(text_item->scaleText() * avg_ratio);
+        }
+    }
 }
 
 void ItemHandler::setDeleteEachQuickItem(QModelIndex parent)
@@ -301,42 +326,6 @@ void ItemHandler::repopulateAnimationModel(const ItemModelItem* const item)
         auto std_item_time_span(new QStandardItem(animation_time_span));
 
         m_animation_model.appendRow(QList<QStandardItem*> { std_item_name, std_item_time_span });
-    }
-}
-
-void ItemHandler::scaleItemsX(const qreal ratio)
-{
-    const auto itemList = basicItems();
-
-    for (auto& item : itemList) {
-        item->setX(qRound(item->x() * ratio));
-    }
-}
-
-void ItemHandler::scaleItemsY(const qreal ratio)
-{
-    const auto itemList = basicItems();
-
-    for (auto& item : itemList) {
-        item->setY(qRound(item->y() * ratio));
-    }
-}
-
-void ItemHandler::scaleItemsWidth(const qreal ratio)
-{
-    const auto itemList = basicItems();
-
-    for (auto& item : itemList) {
-        item->setWidth(qRound(item->width() * ratio));
-    }
-}
-
-void ItemHandler::scaleItemsHeight(const qreal ratio)
-{
-    const auto itemList = basicItems();
-
-    for (auto& item : itemList) {
-        item->setHeight(qRound(item->height() * ratio));
     }
 }
 

--- a/libs/mva_workflow/src/renderer.cpp
+++ b/libs/mva_workflow/src/renderer.cpp
@@ -31,14 +31,15 @@ void Renderer::render(const QList<QSharedPointer<ItemObserver>>& item_list, cons
 {
     qCInfo(renderer) << "Rendering process requested to file " << video_file.absoluteFilePath();
 
+    const auto project_width = QString::number(m_project_settings.size.width());
+    const auto project_height = QString::number(m_project_settings.size.height());
+
     QString program = "ffmpeg";
     QStringList arguments;
     arguments << "-y"
               << "-f"
               << "rawvideo"
-              << "-video_size"
-              << QString::number(m_project_settings.width) + "x" + QString::number(m_project_settings.height)
-              << "-pix_fmt"
+              << "-video_size" << project_width + "x" + project_height << "-pix_fmt"
               << "rgb32"
               << "-r" << QString::number(m_project_settings.fps) << "-i"
               << "-"
@@ -78,7 +79,8 @@ void Renderer::renderingProcessStarted(const QList<QSharedPointer<ItemObserver>>
         auto image = createImage(item_list, frame / qreal(m_project_settings.fps));
         auto imageData = reinterpret_cast<char*>(image.bits());
 
-        qobject_cast<QProcess*>(sender())->write(imageData, m_project_settings.width * m_project_settings.height * 4);
+        qobject_cast<QProcess*>(sender())->write(
+            imageData, m_project_settings.size.width() * m_project_settings.size.height() * 4);
     }
 
     qobject_cast<QProcess*>(sender())->closeWriteChannel();
@@ -100,7 +102,7 @@ void Renderer::renderingProcessFinished(const QFileInfo& video_file, qint32 exit
 
 QImage Renderer::createImage(const QList<QSharedPointer<ItemObserver>>& item_list, const qreal current_time) const
 {
-    QImage image(m_project_settings.width, m_project_settings.height, QImage::Format::Format_RGB32);
+    QImage image(m_project_settings.size, QImage::Format::Format_RGB32);
     image.fill("white");
     QPainter painter(&image);
 
@@ -119,9 +121,7 @@ void Renderer::setProjectSettings(const Renderer::ProjectSettings& new_project_s
     m_project_settings = new_project_settings;
 }
 
-void Renderer::setWidth(const qint32 new_width) { m_project_settings.width = new_width; }
-
-void Renderer::setHeight(const qint32 new_height) { m_project_settings.height = new_height; }
+void Renderer::setProjectSize(const QSize new_project_size) { m_project_settings.size = new_project_size; }
 
 void Renderer::setFPS(const qint32 new_fps) { m_project_settings.fps = new_fps; }
 

--- a/libs/mva_workflow/src/renderer.cpp
+++ b/libs/mva_workflow/src/renderer.cpp
@@ -104,7 +104,7 @@ QImage Renderer::createImage(const QList<QSharedPointer<ItemObserver>>& item_lis
 {
     QImage image(m_project_settings.size, QImage::Format::Format_RGB32);
     image.fill(m_project_settings.background_color);
-  
+
     QPainter painter(&image);
 
     for (const auto& item_observer : item_list) {

--- a/libs/mva_workflow/tests/tst_itemhandler.cpp
+++ b/libs/mva_workflow/tests/tst_itemhandler.cpp
@@ -23,6 +23,7 @@
 #include "fade_in.h"
 #include "fade_out.h"
 #include "itemhandler.h"
+#include "rectangle.h"
 
 class TestItemHandler : public QObject {
     Q_OBJECT
@@ -332,7 +333,7 @@ void TestItemHandler::scaleItemsPosX()
     itemhandler.addItem(rect);
 
     const qreal ratio = 0.65;
-    itemhandler.scaleItemsX(ratio);
+    itemhandler.scaleItems(ratio, 1.0);
 
     QCOMPARE(circle->x(), qRound(circle_x_old * ratio));
     QCOMPARE(circle->y(), circle_y_old);
@@ -358,7 +359,7 @@ void TestItemHandler::scaleItemsPosY()
     rect->setPosition(QPointF(rect_x_old, rect_y_old));
 
     const qreal ratio = 1.4;
-    itemhandler.scaleItemsY(ratio);
+    itemhandler.scaleItems(1.0, ratio);
 
     QCOMPARE(circle->x(), circle_x_old);
     QCOMPARE(circle->y(), qRound(circle_y_old * ratio));
@@ -375,17 +376,26 @@ void TestItemHandler::scaleItemsWidth()
     const qreal circle_height_old = 133;
     const qreal rect_width_old = 116;
     const qreal rect_height_old = 332;
+    const qreal circle_border_width_old = 20;
+    const qreal rect_border_width_old = 5;
 
     items[0]->setSize(QSizeF(circle_width_old, circle_height_old));
+    qobject_cast<CircleItem*>(items[0]->abstractItem())->setBorderWidth(circle_border_width_old);
     items[1]->setSize(QSizeF(rect_width_old, rect_height_old));
+    qobject_cast<RectangleItem*>(items[1]->abstractItem())->setBorderWidth(rect_border_width_old);
 
     const qreal ratio = 1.2;
-    itemhandler.scaleItemsWidth(ratio);
+    const qreal avg_ratio = (ratio + 1.0) / 2.0;
+    itemhandler.scaleItems(ratio, 1.0);
 
     QCOMPARE(items[0]->width(), qRound(circle_width_old * ratio));
     QCOMPARE(items[0]->height(), circle_height_old);
+    QCOMPARE(qobject_cast<CircleItem*>(items[0]->abstractItem())->borderWidth(),
+        qRound(avg_ratio * circle_border_width_old));
     QCOMPARE(items[1]->width(), qRound(rect_width_old * ratio));
     QCOMPARE(items[1]->height(), rect_height_old);
+    QCOMPARE(qobject_cast<RectangleItem*>(items[1]->abstractItem())->borderWidth(),
+        qRound(avg_ratio * rect_border_width_old));
 }
 
 void TestItemHandler::scaleItemsHeight()
@@ -397,21 +407,30 @@ void TestItemHandler::scaleItemsHeight()
     const qreal circle_height_old = 276;
     const qreal rect_width_old = 454;
     const qreal rect_height_old = 238;
+    const qreal circle_border_width_old = 50;
+    const qreal rect_border_width_old = 35;
 
     circle->setSize(QSizeF(circle_width_old, circle_height_old));
+    qobject_cast<CircleItem*>(circle->abstractItem())->setBorderWidth(circle_border_width_old);
     rect->setSize(QSizeF(rect_width_old, rect_height_old));
+    qobject_cast<RectangleItem*>(rect->abstractItem())->setBorderWidth(rect_border_width_old);
 
     ItemHandler itemhandler;
     itemhandler.addItem(circle);
     itemhandler.addItem(rect);
 
     const qreal ratio = 0.4;
-    itemhandler.scaleItemsHeight(ratio);
+    const qreal avg_ratio = (ratio + 1.0) / 2.0;
+    itemhandler.scaleItems(1.0, ratio);
 
     QCOMPARE(circle->height(), qRound(circle_height_old * ratio));
     QCOMPARE(circle->width(), circle_width_old);
+    QCOMPARE(
+        qobject_cast<CircleItem*>(circle->abstractItem())->borderWidth(), qRound(avg_ratio * circle_border_width_old));
     QCOMPARE(rect->height(), qRound(rect_height_old * ratio));
     QCOMPARE(rect->width(), rect_width_old);
+    QCOMPARE(
+        qobject_cast<RectangleItem*>(rect->abstractItem())->borderWidth(), qRound(avg_ratio * rect_border_width_old));
 }
 
 void TestItemHandler::getItems()

--- a/libs/mva_workflow/tests/tst_renderer.cpp
+++ b/libs/mva_workflow/tests/tst_renderer.cpp
@@ -119,7 +119,8 @@ void TestRenderer::createImage_data()
 
     Renderer::ProjectSettings defaultProjectSettings;
 
-    QTest::newRow("default_setup") << defaultProjectSettings.height << defaultProjectSettings.width << default_frame;
+    QTest::newRow("default_setup") << defaultProjectSettings.size.height() << defaultProjectSettings.size.width()
+                                   << default_frame;
     QTest::newRow("mod_values") << 750 << 1250 << mod_frame;
 }
 
@@ -132,8 +133,7 @@ void TestRenderer::createImage()
     Renderer renderer;
 
     Renderer::ProjectSettings project_settings;
-    project_settings.width = width;
-    project_settings.height = height;
+    project_settings.size = QSize(width, height);
 
     renderer.setProjectSettings(project_settings);
     const auto rendered_image = renderer.createImage(m_item_list, 0.0);
@@ -158,7 +158,7 @@ void TestRenderer::render_data()
 
     Renderer::ProjectSettings defaultProjectSettings;
 
-    QTest::newRow("default_setup") << defaultProjectSettings.height << defaultProjectSettings.width
+    QTest::newRow("default_setup") << defaultProjectSettings.size.height() << defaultProjectSettings.size.width()
                                    << defaultProjectSettings.fps << defaultProjectSettings.video_length
                                    << home_dir_video << default_frame;
     QTest::newRow("mod_values") << 750 << 1250 << 32 << 10 << temp_dir_video << mod_frame;
@@ -201,8 +201,7 @@ void TestRenderer::render()
         });
 
     Renderer::ProjectSettings project_settings;
-    project_settings.width = width;
-    project_settings.height = height;
+    project_settings.size = QSize(width, height);
     project_settings.fps = fps;
     project_settings.video_length = video_length;
 
@@ -341,19 +340,16 @@ void TestRenderer::renderWithAnimation()
 void TestRenderer::setIndividualProjectSettings()
 {
     Renderer renderer;
-    const qint32 width = 1200;
-    const qint32 height = 888;
+    const QSize project_size = QSize(1200, 888);
     const qint32 fps = 15;
     const qint32 video_length = 12;
 
-    renderer.setWidth(width);
-    renderer.setHeight(height);
+    renderer.setProjectSize(project_size);
     renderer.setFPS(fps);
     renderer.setVideoLength(video_length);
 
     const auto renderer_project_settings = renderer.projectSettings();
-    QCOMPARE(renderer_project_settings.width, width);
-    QCOMPARE(renderer_project_settings.height, height);
+    QCOMPARE(renderer_project_settings.size, project_size);
     QCOMPARE(renderer_project_settings.fps, fps);
     QCOMPARE(renderer_project_settings.video_length, video_length);
 }


### PR DESCRIPTION
Fixes #128

### Proposed changes

* Border Width and TextScale property are now scaled when project size changes
* Replace pixel_width and height property with one project_size property

### Motivation behind changes

Correct scaling makes it easier for the user to change the size of the project during development.
Using QSize for the project_size property is much more flexible and useful than having two properties

### Test plan

All tests were updated accordingly.

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [x] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [x] To the best of my knowledge, the proposed patch is not based on a code under
GPL or other license that is incompatible with MathVizAnimator

* [x] The PR is proposed to proper branch

* [x] There is reference to original bug report and related work

* [x] There is accuracy test, performance test and test data in the repository,
if applicable
