### PR TITLE
Add Save option in menu

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -41,6 +41,7 @@
     "QUICKITEM",
     "QVERIFY",
     "SAVEFILEHANDLER",
+    "STRG",
     "TEXTITEM",
     "Doxyfile",
     "Schoos",

--- a/app/src/mainlogic.cpp
+++ b/app/src/mainlogic.cpp
@@ -142,6 +142,9 @@ void MainLogic::loadProject(const QFileInfo& load_file_info)
     setProjectSettings(json["project-settings"].toObject());
 
     for (const QString& itemKey : json.keys()) {
+        if (!itemKey.startsWith("item_")) {
+            continue;
+        }
         auto item_json = json[itemKey].toObject();
 
         QQmlComponent component(m_qml_engine, QUrl(item_json["abstract_item.file"].toString()));

--- a/app/tests/integration_tests/test_helper_functions.cpp
+++ b/app/tests/integration_tests/test_helper_functions.cpp
@@ -259,7 +259,7 @@ QString TestHelperFunctions::copyFileToTestDir(const QFile& file, const QString&
         QFile::remove(file_path);
     }
 
-    if (!QFile::copy(file.fileName(), file_path)) {
+    if (!QFile::copy(file.fileName(), file_path)) { // NOLINT, false positive
         return QString();
     }
     QFile::setPermissions(file_path, QFileDevice::ReadOwner | QFileDevice::WriteOwner);

--- a/app/tests/integration_tests/test_helper_functions.cpp
+++ b/app/tests/integration_tests/test_helper_functions.cpp
@@ -248,7 +248,7 @@ bool TestHelperFunctions::loadFile(const QString& full_file_path) const
     return QTest::qWaitFor([&]() { return !load_file_dialog->property("visible").toBool(); });
 }
 
-QString TestHelperFunctions::copyFileToTestDir(QFile& file, const QString& new_file_name) const
+QString TestHelperFunctions::copyFileToTestDir(const QFile& file, const QString& new_file_name) const
 {
     if (!file.exists()) {
         return QString();
@@ -259,7 +259,7 @@ QString TestHelperFunctions::copyFileToTestDir(QFile& file, const QString& new_f
         QFile::remove(file_path);
     }
 
-    if (!file.copy(file_path)) {
+    if (!QFile::copy(file.fileName(), file_path)) {
         return QString();
     }
     QFile::setPermissions(file_path, QFileDevice::ReadOwner | QFileDevice::WriteOwner);

--- a/app/tests/integration_tests/test_helper_functions.h
+++ b/app/tests/integration_tests/test_helper_functions.h
@@ -67,6 +67,12 @@ class TestHelperFunctions {
     bool renderVideo(const QString& render_file) const;
     QImage extractImage(const QString& video_file) const;
 
+    void saveFile() const;
+    bool saveFileAs(const QString& full_file_path) const;
+    bool loadFile(const QString& full_file_path) const;
+
+    QString copyFileToTestDir(QFile& file, const QString& new_file_name) const;
+
     template <typename T> T getChild(const QString& name) const
     {
         auto child = m_quick_window->findChild<T>(name);

--- a/app/tests/integration_tests/test_helper_functions.h
+++ b/app/tests/integration_tests/test_helper_functions.h
@@ -71,7 +71,7 @@ class TestHelperFunctions {
     bool saveFileAs(const QString& full_file_path) const;
     bool loadFile(const QString& full_file_path) const;
 
-    QString copyFileToTestDir(QFile& file, const QString& new_file_name) const;
+    QString copyFileToTestDir(const QFile& file, const QString& new_file_name) const;
 
     template <typename T> T getChild(const QString& name) const
     {

--- a/docs/first_steps/index.rst
+++ b/docs/first_steps/index.rst
@@ -153,10 +153,12 @@ The animated video can be rendered by clicking on **Project->Render** and choose
 Save the project
 ++++++++++++++++
 
-The project can be saved by clicking on **File->Save As** and choose file name and destination. There is currently no option to save via shortcut or directly to the same file. You have to overwrite your save file by following the process as explained before.
+The project can be saved by clicking on **File->Save As** and choose file name and destination. 
 
 .. image:: images/save_project.png
   :width: 600
   :alt: Save project menu
+
+Clicking on **File->Save** will save the project to the current file, which is either the last file saved to or the last file which was loaded using **File->Open Project**. If there is no current file, a file dialog will be opened to specify a file. There is currently no option to save via shortcut like *STRG + S*. 
 
 .. note:: The files (save file, video and snapshot) of this example can be found in the examples/first_steps folder of the repository.

--- a/libs/mva_gui/qml/MainWindow.qml
+++ b/libs/mva_gui/qml/MainWindow.qml
@@ -32,7 +32,9 @@ ApplicationWindow {
     visible: true
     width: 1600
     height: 1200
-    title: qsTr("mathvizanimator")
+    title: saveFile.toString(
+               ) === "" ? qsTr("mathvizanimator") : qsTr(
+                              "mathvizanimator") + " - " + saveFileTitle
 
     font.pointSize: 14
 
@@ -44,6 +46,7 @@ ApplicationWindow {
     property ApplicationWindow appWindow: root
     property string thekey: "MVADropAreaKey"
     property url saveFile: ""
+    property string saveFileTitle: saveFile.toString().substring(7)
     property var dragItem: null
     property bool objectDragActive: false
 
@@ -69,6 +72,7 @@ ApplicationWindow {
         onAccepted: {
             newAction.trigger(loadFileDialog)
             main_window.loadProject(selectedFile)
+            saveFile = selectedFile
         }
 
         // Necessary for integration testing, close() is needed for macOS test, it crashes (segmentation fault) otherwise
@@ -88,7 +92,10 @@ ApplicationWindow {
         defaultSuffix: ".json"
         nameFilters: ["JSON (*.json)"]
 
-        onAccepted: main_window.saveProject(selectedFile)
+        onAccepted: {
+            main_window.saveProject(selectedFile)
+            saveFile = selectedFile
+        }
 
         // Necessary for integration testing, close() is needed for macOS test, it crashes (segmentation fault) otherwise
         function simulateAccepted() {
@@ -365,6 +372,21 @@ ApplicationWindow {
 
                 text: qsTr("&Open...")
                 onTriggered: loadFileDialog.open()
+            }
+
+            Action {
+                id: saveAction
+                objectName: "MVASaveProjectAction"
+
+                text: qsTr("&Save")
+                onTriggered: {
+                    if (saveFile.toString() === "") {
+                        saveAsAction.trigger()
+                        return
+                    }
+
+                    main_window.saveProject(saveFile)
+                }
             }
 
             Action {

--- a/libs/mva_gui/qml/MainWindow.qml
+++ b/libs/mva_gui/qml/MainWindow.qml
@@ -370,7 +370,7 @@ ApplicationWindow {
                 id: loadAction
                 objectName: "MVALoadProjectAction"
 
-                text: qsTr("&Open...")
+                text: qsTr("&Open Project")
                 onTriggered: loadFileDialog.open()
             }
 
@@ -393,7 +393,7 @@ ApplicationWindow {
                 id: saveAsAction
                 objectName: "MVASaveProjectAsAction"
 
-                text: qsTr("Save &As...")
+                text: qsTr("Save &As")
                 onTriggered: saveFileDialog.open()
             }
 


### PR DESCRIPTION
Fixes #38 

### Proposed changes

* File can now be saved using File->Save and no file dialog pops up
* Add gui tests accordingly

### Motivation behind changes

Easier to use and standard to have a "Save" option beside a "Save As" option

### Test plan

GUI Tests were added and successfull

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](CONTRIBUTING.md).

* [x] I agree to contribute to the project under MathVizAnimator (GNU General Public License v3.0)
[License](LICENSE).

* [x] To the best of my knowledge, the proposed patch is not based on a code under
a license that is incompatible with MathVizAnimator.

* [x] The PR is proposed to proper branch.

* [x] There is reference to original bug report and related work.

* [x] There is a unit test and or integration test added if necessary.

* [ ] The feature is well documented and an example was added if necessary.
